### PR TITLE
Improve news sharing and update API URLs

### DIFF
--- a/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.ts
+++ b/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.ts
@@ -83,16 +83,38 @@ export class NewsDetailComponent implements OnInit {
 
   shareNews() {
     if (navigator.share) {
+      // Caso o navegador suporte Web Share API
       navigator.share({
         title: this.news.title,
         text: this.news.summary,
         url: window.location.href
-      });
+      }).catch(err => console.error("Erro ao compartilhar:", err));
+    } else if (navigator.clipboard && window.isSecureContext) {
+      // HTTPS ou localhost
+      navigator.clipboard.writeText(window.location.href)
+        .then(() => alert('Link copiado para a área de transferência!'))
+        .catch(err => console.error("Erro ao copiar:", err));
     } else {
-      navigator.clipboard.writeText(window.location.href);
-      alert('Link copiado para a área de transferência!');
+      // Fallback para HTTP (ou navegadores antigos)
+      const textArea = document.createElement("textarea");
+      textArea.value = window.location.href;
+      textArea.style.position = "fixed"; // evita scroll ao focar
+      textArea.style.left = "-9999px";
+      document.body.appendChild(textArea);
+      textArea.focus();
+      textArea.select();
+
+      try {
+        document.execCommand('copy');
+        alert('Link copiado para a área de transferência!');
+      } catch (err) {
+        console.error("Erro ao copiar com fallback:", err);
+      }
+
+      document.body.removeChild(textArea);
     }
   }
+
 
   printNews() {
     window.print();

--- a/portalsantacasa.client/src/environments/environment.ts
+++ b/portalsantacasa.client/src/environments/environment.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: false,
-  apiUrl: 'https://localhost:7057/api',
-  imageServerUrl: 'https://localhost:7057/'
+  apiUrl: 'https://localhost:44323/api',
+  imageServerUrl: 'https://localhost:44323/'
 };


### PR DESCRIPTION
Enhanced the shareNews method to support Web Share API, clipboard copy in secure contexts, and a fallback for older browsers. Updated environment API and image server URLs to use port 44323.