### PR TITLE
Update GetAllPaginatedAsync to accept nullable filter

### DIFF
--- a/PortalSantaCasa.Server/Controllers/NewsController.cs
+++ b/PortalSantaCasa.Server/Controllers/NewsController.cs
@@ -32,7 +32,7 @@ namespace PortalSantaCasa.Server.Controllers
                 currentPage = page,
                 perPage,
                 news = result,
-                pages = (int)Math.Ceiling((double)await GetTotalPages(perPage))
+                pages = (int)Math.Ceiling((double)await GetTotalPages(perPage, isQualityMinute))
             });
         }
 
@@ -67,9 +67,9 @@ namespace PortalSantaCasa.Server.Controllers
             return NoContent();
         }
 
-        private async Task<int> GetTotalPages(int perPage)
+        private async Task<int> GetTotalPages(int perPage, bool? isQualityMinute)
         {
-            var total = await _service.GetAllPaginatedAsync(1, int.MaxValue);
+            var total = await _service.GetAllPaginatedAsync(1, int.MaxValue, isQualityMinute);
             return (int)Math.Ceiling(total.Count() / (double)perPage);
         }
     }

--- a/PortalSantaCasa.Server/Interfaces/INewsService.cs
+++ b/PortalSantaCasa.Server/Interfaces/INewsService.cs
@@ -5,7 +5,7 @@ namespace PortalSantaCasa.Server.Interfaces
     public interface INewsService
     {
         Task<IEnumerable<NewsResponseDto>> GetAllAsync();
-        Task<IEnumerable<NewsResponseDto>> GetAllPaginatedAsync(int page, int perPage, bool isQualityMinute);
+        Task<IEnumerable<NewsResponseDto>> GetAllPaginatedAsync(int page, int perPage, bool? isQualityMinute);
         Task<NewsResponseDto?> GetByIdAsync(int id);
         Task<NewsResponseDto> CreateAsync(NewsCreateDto dto);
         Task<bool> UpdateAsync(int id, NewsUpdateDto dto);

--- a/PortalSantaCasa.Server/Services/NewsService.cs
+++ b/PortalSantaCasa.Server/Services/NewsService.cs
@@ -35,7 +35,7 @@ namespace PortalSantaCasa.Server.Services
             .ToListAsync();
         }
 
-        public async Task<IEnumerable<NewsResponseDto>> GetAllPaginatedAsync(int page, int perPage, bool isQualityMinute)
+        public async Task<IEnumerable<NewsResponseDto>> GetAllPaginatedAsync(int page, int perPage, bool? isQualityMinute)
         {
             var query = _context.News
                 .Where(n => n.IsQualityMinute == isQualityMinute)


### PR DESCRIPTION
Changed the isQualityMinute parameter in GetAllPaginatedAsync to be nullable (bool?) across the service, interface, and controller. This allows for more flexible filtering of news items, including cases where the filter is not applied.