### PR TITLE
Add model snapshot and update internal announcement detail

### DIFF
--- a/PortalSantaCasa.Server/PortalSantaCasa.Server.csproj
+++ b/PortalSantaCasa.Server/PortalSantaCasa.Server.csproj
@@ -45,6 +45,7 @@
 
 	<ItemGroup>
 		<Folder Include="Uploads\" />
+		<Folder Include="wwwroot\browser\" />
 	</ItemGroup>
 	
 	<Target Name="BuildAngular" BeforeTargets="Publish">

--- a/portalsantacasa.client/src/app/pages/internal-announcement-detail/internal-announcement-detail.component.html
+++ b/portalsantacasa.client/src/app/pages/internal-announcement-detail/internal-announcement-detail.component.html
@@ -81,7 +81,7 @@
                 <i class="fas fa-file-alt"></i>
               </div>
               <h6 class="card-title">{{ related.title }}</h6>
-              <p class="card-text text-muted small">{{ getExcerpt(related.content) }}</p>
+              <p class="card-text text-muted small" [innerHTML]="getExcerpt(related.content)"></p>
               <small class="text-muted">{{ related.publishDate | date:'shortDate' }}</small>
             </div>
           </div>


### PR DESCRIPTION
Added PortalSantaCasaDbContextModelSnapshot for EF Core migrations. Updated internal-announcement-detail.component.html to use [innerHTML] for rendering excerpts, allowing HTML content. Also added a new wwwroot\browser folder to the server project.