### PR TITLE
Add SIPAT modal to home page

### DIFF
--- a/portalsantacasa.client/src/app/pages/home/home.component.html
+++ b/portalsantacasa.client/src/app/pages/home/home.component.html
@@ -290,3 +290,49 @@
     </div>
   </div>
 </div>
+
+<!-- Modal de SIPAT -->
+<div *ngIf="showSipat" class="notificacao-modal-overlay" (click)="closeSipatModal()">
+  <div class="notificacao-modal-content" (click)="$event.stopPropagation()">
+
+    <!-- Header com imagem e botão fechar -->
+    <div class="notificacao-modal-header">
+      <button class="notificacao-modal-close" (click)="closeSipatModal()" aria-label="Fechar modal">
+        <i class="fas fa-times"></i>
+      </button>
+
+      <img src="assets/img/care-icon.png" alt="Ícone SIPAT" class="notificacao-modal-image">
+    </div>
+
+    <!-- Corpo do modal -->
+    <div class="notificacao-modal-body">
+      <h2 class="notificacao-modal-title">
+        SIPAT – Semana Interna de Prevenção de Acidentes
+      </h2>
+
+      <p class="notificacao-modal-text">
+        Participe das atividades da <span class="notificacao-text-highlight">SIPAT</span> e contribua
+        para a promoção de um ambiente de trabalho mais seguro, saudável e consciente para todos.
+      </p>
+
+      <div class="notificacao-modal-description">
+        <i class="fas fa-hard-hat" style="margin-right: 8px; color: #3b82f6;"></i>
+        Sua participação é fundamental para fortalecer a cultura de segurança e prevenir acidentes no ambiente de trabalho.
+      </div>
+
+      <div class="notificacao-modal-actions">
+        <button class="notificacao-btn-cancelar" (click)="closeSipatModal()">
+          <i class="fas fa-arrow-left"></i>
+          Voltar
+        </button>
+
+        <a href="https://forms.office.com/pages/responsepage.aspx?id=DB4RA4G6_ESTlE1x4exdDspIKvEzKW5Ft5yTQijhRMJURDhYV1g2MEtJTFEyUlJTT1VaUjVGMDAwTC4u&route=shorturl"
+           target="_blank"
+           class="notificacao-btn-criar">
+          <i class="fas fa-check-circle"></i>
+          Participar da SIPAT
+        </a>
+      </div>
+    </div>
+  </div>
+</div>

--- a/portalsantacasa.client/src/app/pages/home/home.component.ts
+++ b/portalsantacasa.client/src/app/pages/home/home.component.ts
@@ -22,6 +22,7 @@ export class HomeComponent implements OnInit {
   showFeedback = false;
   showNotificacao = false;
   showNotificacao2 = false;
+  showSipat = false;
   banners: Banner[] = [];
   currentSlide = 0;
   progress = 0;
@@ -104,6 +105,15 @@ export class HomeComponent implements OnInit {
       buttonText: 'Enviar denúncia',
       btnClass: 'custom-bg-btn',
       action: () => this.openNotificacao2Modal()
+    },
+    {
+      title: 'SIPAT',
+      description: 'Participe da Semana Interna de Prevenção de Acidentes',
+      icon: 'fas fa-hard-hat',
+      iconColor: '#198754',
+      buttonText: 'Ver mais',
+      btnClass: 'custom-bg-btn',
+      action: () => this.openSipatModal()
     },
     {
       title: 'Cardápio',
@@ -367,6 +377,14 @@ export class HomeComponent implements OnInit {
 
   openNotificacaoModal() {
     this.showNotificacao = true;
+  }
+
+  openSipatModal() {
+    this.showSipat = true;
+  }
+
+  closeSipatModal() {
+    this.showSipat = false;
   }
 
   openNotificacao2Modal() {


### PR DESCRIPTION
Introduces a modal for SIPAT (Semana Interna de Prevenção de Acidentes) on the home page, including UI elements and logic to open and close the modal. Updates the notification actions to include SIPAT participation.