### PR TITLE
Update menu label from Formulários to Notificações

### DIFF
--- a/portalsantacasa.client/src/app/components/header/header.component.html
+++ b/portalsantacasa.client/src/app/components/header/header.component.html
@@ -75,7 +75,7 @@
                routerLinkActive="active"
                class="nav-link">
               <i class="fas fa-file-alt"></i>
-              <span>Formulários</span>
+              <span>Notificações</span>
             </a>
           </li>
 


### PR DESCRIPTION
Changed the navigation link text in the header component from 'Formulários' to 'Notificações' to better reflect its purpose.