### PR TITLE
Map EF entities to tables and update prod config

### DIFF
--- a/PortalSantaCasa.Server/Context/PortalSantaCasaDbContext.cs
+++ b/PortalSantaCasa.Server/Context/PortalSantaCasaDbContext.cs
@@ -34,6 +34,29 @@ namespace PortalSantaCasa.Server.Context
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+            modelBuilder.Entity<Banner>().ToTable("banners");
+            modelBuilder.Entity<Birthday>().ToTable("birthdays");
+            modelBuilder.Entity<Chat>().ToTable("chats");
+            modelBuilder.Entity<ChatMessage>().ToTable("chatmessages");
+            modelBuilder.Entity<ChatMessageFile>().ToTable("chatmessagefiles");
+            modelBuilder.Entity<ChatParticipant>().ToTable("chatparticipants");
+            modelBuilder.Entity<Cid10>().ToTable("cid10");
+            modelBuilder.Entity<CidProcedimento>().ToTable("cidprocedimentos");
+            modelBuilder.Entity<Course>().ToTable("courses");
+            modelBuilder.Entity<Document>().ToTable("documents");
+            modelBuilder.Entity<Event>().ToTable("events");
+            modelBuilder.Entity<Feedback>().ToTable("feedbacks");
+            modelBuilder.Entity<Form>().ToTable("forms");
+            modelBuilder.Entity<InternalAnnouncement>().ToTable("internalannouncements");
+            modelBuilder.Entity<Menu>().ToTable("menus");
+            modelBuilder.Entity<News>().ToTable("news");
+            modelBuilder.Entity<Notification>().ToTable("notifications");
+            modelBuilder.Entity<Procedimento>().ToTable("procedimentos");
+            modelBuilder.Entity<TussDePara>().ToTable("tussdepara");
+            modelBuilder.Entity<User>().ToTable("users");
+            modelBuilder.Entity<UserCourse>().ToTable("usercourses");
+            modelBuilder.Entity<UserNotification>().ToTable("usernotifications");
+
             // USER - Username único
             modelBuilder.Entity<User>()
                 .HasIndex(u => u.Username)

--- a/PortalSantaCasa.Server/Program.cs
+++ b/PortalSantaCasa.Server/Program.cs
@@ -87,7 +87,10 @@ builder.Services.AddCors(options =>
     {
         policy.WithOrigins(
                 "https://localhost:53598",
-                "http://intranet.sp.santacasalorena.org.br")
+                "http://intranet.santacasalorena.org.br",
+                "https://intranet.santacasalorena.org.br",
+                "http://intranet.sp.santacasalorena.org.br",
+                "http://docker-w3.sp.santacasalorena.org.br:8085/")
               .AllowAnyHeader()
               .AllowAnyMethod()
               .AllowCredentials();
@@ -188,7 +191,7 @@ if (app.Environment.IsDevelopment())
 }
 
 // HTTPS, Auth
-app.UseHttpsRedirection();
+//app.UseHttpsRedirection();
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/PortalSantaCasa.Server/appsettings.Production.json
+++ b/PortalSantaCasa.Server/appsettings.Production.json
@@ -2,19 +2,31 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
+      "Microsoft.AspNetCore": "Warning",
+      "Microsoft.AspNetCore.SignalR": "Debug"
+      //"Microsoft.AspNetCore.Authentication": "Debug",
+      //"Microsoft.AspNetCore.Hosting": "Information"
     }
   },
+  "Kestrel": {
+    "Endpoints": {
+      "Http": {
+        "Url": "http://0.0.0.0:8085"
+      }
+    }
+  },
+  "AllowedHosts": "*",
+
   "Jwt": {
     "Key": "-_N!8c3jwuh,3BTz6#3^PfPdJsM8aY3FsP)mtbb-Sb7|Kc1sr8|gf4r{zJ>JD{w/d/H={Aze!7TxB;[gKBVXT.OraDbpJfr+U]G6hWfSWTA6D/WpuKOJIk+V^jAAR{.$HG%uYw?I#UaUClctxChw>Jqw9DVNXxJ+0t&$F.g+)4GtB,RnvDh$^%/a&.a]bjV_[#Q.}vhC&=#Zc]4O+tmam/Jc?Go-4{/fEpM]<SSuV#svyPu?kBtu_Z?Th{yN)UmZ-SPzIYBM[5[!ih7GP/Gy%hp?RD<6=k9|!z;.h{*nuTy[KLpGQTiYk^wjZPmJ3kf7HR;yg,C*S0s={hs?QnK9NF9dK5f6E||q*M?!^Al8$Zuh|ewWe>pbs#o;IZla@H{E;[7(K80Z)Z1mZ4iKfeXM%?&H>S=4{?/oe[jqBt%0$R6GtEnAfX%$-XH6OfXBwq:oAM5=nlJ)0CUrX!JZ3E%<+XyAy]=r{V{$X.f=n?[k}Wm<yDq/eSZ/bL(lT1n]_QAu",
-    "Issuer": "intranet.sp.santacasalorena.org.br",
-    "Audience": "intranet.sp.santacasalorena.org.br"
+    "Issuer": "intranet.santacasalorena.org.br",
+    "Audience": "intranet.santacasalorena.org.br"
   },
   "ConnectionStrings": {
-    "PortalSclConnectionString": "server=192.168.20.233;port=3306;database=PortalScl;user=root;password=Scl.Lorena@1867"
+    "PortalSclConnectionString": "Server=mysql80;Port=3306;Database=db_intranet-santacasalorena-org-br;User=usr_app-santacasalorena-org-br;Password=\"B:Um(50Q4V<K7_+*\";CharSet=utf8mb4;"
   },
   "Matomo": {
-    "BaseUrl": "http://intranet.sp.santacasalorena.org.br/matomo/",
+    "BaseUrl": "https://intranet.santacasalorena.org.br/matomo/",
     "SiteId": 1
   }
 }

--- a/portalsantacasa.client/package-lock.json
+++ b/portalsantacasa.client/package-lock.json
@@ -349,6 +349,7 @@
       "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.1.4.tgz",
       "integrity": "sha512-y4mq2r6jhAj5QuA3UnWkVfok0EcA22uH+XVb4HBKY7q23/xaQYu2CGdVOVpdUsaPTf3zRD1DkAnTkV3J3ZHIiA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -544,6 +545,7 @@
       "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.1.4.tgz",
       "integrity": "sha512-AL+HdsY5xL2iM1zZ55ce33U+w2LgPJZQwKvHXJJ/Hpk3rpFNamWtRPmJBeq8Z0dQV1lLTMM+2pUatH6p+5pvEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -560,6 +562,7 @@
       "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.1.4.tgz",
       "integrity": "sha512-gQbchh2ziK9QxZuHgEf7BUMCm/ayu6Zr9hst6itSecinUJgUeeSp3Z4vXjIBNBUKMPB135tWw9RGiVbW8saBmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -573,6 +576,7 @@
       "integrity": "sha512-I603/3EmclgX4VUryBo3bxlF+8+fVucrW/V0leqNlt72ppFTphDiKiopogoJFWJxuULTo2V+7Koq8Em7kUO67Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "7.28.0",
         "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -653,6 +657,7 @@
       "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.1.4.tgz",
       "integrity": "sha512-aWDux64a9usuVU2SnF0epqjXAj8JO8jViUzZAJAuFKSCtkeNzqP+Z6DjkqsCKrNvGP7xkX1XhhepUygxgh7/6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -678,6 +683,7 @@
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.1.4.tgz",
       "integrity": "sha512-5gUwcV+JpzJ2rSPo1nR6iNz2Dm3iRcVCvRTsVnKhFbZCIbGLihLpoCuittsgUY/C9wh/rnmXlatmLJ7giSuUZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -696,6 +702,7 @@
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.1.4.tgz",
       "integrity": "sha512-z86NsGSwm5pXCACdWBbp7SC1Xn+UGvuoRqTsi0dNUXT/3WrP6MvZT3TfNKwM63GLUqFAICSt7uFXS84D72ukvA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -789,6 +796,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.7.tgz",
       "integrity": "sha512-BU2f9tlKQ5CAthiMIgpzAh4eDTLWo1mqi9jqE2OxMG0E/OM199VJt2q8BztTxpnSW0i1ymdwLXRJnYzvDM5r2w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -2203,6 +2211,7 @@
       "integrity": "sha512-jAhL7tyMxB3Gfwn4HIJ0yuJ5pvcB5maYUcouGcgd/ub79f9MqZ+aVnBtuFf+VC2GTkCBF+R+eo7Vi63w5VZlzw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^4.1.9",
         "@inquirer/confirm": "^5.1.13",
@@ -4639,6 +4648,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4983,6 +4993,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001726",
         "electron-to-chromium": "^1.5.173",
@@ -5253,6 +5264,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -6085,6 +6097,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6554,6 +6567,7 @@
       "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.0",
@@ -7253,7 +7267,7 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7648,7 +7662,8 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
       "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jest-diff": {
       "version": "30.0.5",
@@ -8404,6 +8419,7 @@
       "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
@@ -10578,6 +10594,7 @@
       "resolved": "https://registry.npmjs.org/quill/-/quill-2.0.3.tgz",
       "integrity": "sha512-xEYQBqfYx/sfb33VJiKnSJp8ehloavImQ2A6564GAbqG55PGw1dAWUn1MUbQB62t0azawUS2CZZhWCjO8gRvTw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
         "lodash-es": "^4.17.21",
@@ -10840,6 +10857,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10887,7 +10905,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/sass": {
@@ -10896,6 +10914,7 @@
       "integrity": "sha512-xCmtksBKd/jdJ9Bt9p7nPKiuqrlBMBuuGkQlkhZjjQk3Ty48lv93k5Dq6OPkKt4XwxDJ7tvlfrTa1MPA9bf+QA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -11868,7 +11887,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/tuf-js": {
       "version": "3.1.0",
@@ -11932,6 +11952,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12126,6 +12147,7 @@
       "integrity": "sha512-MHFiOENNBd+Bd9uvc8GEsIzdkn1JxMmEeYX35tI3fv0sJBUTfW5tQsoaOwuY4KhBI09A3dUJ/DXf2yxPVPUceg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -12552,6 +12574,7 @@
       "integrity": "sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12570,7 +12593,8 @@
       "version": "0.15.1",
       "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
       "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/portalsantacasa.client/src/environments/environment.prod.ts
+++ b/portalsantacasa.client/src/environments/environment.prod.ts
@@ -1,5 +1,5 @@
 export const environment = {
   production: true,
-  apiUrl: 'http://intranet.sp.santacasalorena.org.br/api',
-  serverUrl: 'http://intranet.sp.santacasalorena.org.br/'
+  apiUrl: 'https://intranet.santacasalorena.org.br/api',
+  serverUrl: 'https://intranet.santacasalorena.org.br/'
 };


### PR DESCRIPTION
Add explicit ToTable mappings for all domain entities in PortalSantaCasaDbContext. Update Program.cs: expand allowed CORS origins to include intranet and docker hosts and temporarily disable HTTPS redirection. Revise appsettings.Production.json to enable SignalR logging, add a Kestrel HTTP endpoint (0.0.0.0:8085), set AllowedHosts, change JWT issuer/audience to the new intranet domain, switch the DB connection to the containerized MySQL host, and update Matomo URL to the secure intranet address. Update client production environment to point API and server URLs to the new https intranet domain. These changes align server and client configuration for the new deployment/environment.