### PR TITLE
Prevent adding duplicate chats to list

### DIFF
--- a/portalsantacasa.client/src/app/admin/pages/chat/chat.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/chat/chat.component.ts
@@ -501,6 +501,12 @@ export class ChatComponent implements OnInit, AfterViewChecked, OnDestroy {
   }
 
   private addNewChatToList(chat: ChatDto): void {
+
+    const chatExistente = this.chatList.find(c => c.id === chat.id);
+    if (chatExistente) {
+      return; // Se já existe, não faz nada e evita a duplicata
+    }
+
     const otherUser = chat.members.find(member => member.id !== this.loggedUserId);
 
     let nomeExibido = chat.name;


### PR DESCRIPTION
Add an existence check in addNewChatToList that finds a chat by id on chatList and returns early if found, avoiding duplicate chat entries when the same chat is added multiple times.