### PR TITLE
Add role-based access control to admin routes

### DIFF
--- a/portalsantacasa.client/src/app/admin/admin-routing.module.ts
+++ b/portalsantacasa.client/src/app/admin/admin-routing.module.ts
@@ -20,26 +20,27 @@ import { FormsRegisterComponent } from './pages/forms/forms-register.component';
 import { OnlineUsersComponent } from './pages/online-users/online-users.component';
 import { DiagnosticoComponent } from './pages/diagnostico/diagnostico.component';
 import { AtualizacaoArquivosComponent } from './pages/atualizacao-arquivos/atualizacao-arquivos.component';
+import { RoleGuard } from '../core/guards/role.guard';
 
 const routes: Routes = [
-  { path: 'dashboard', component: DashboardComponent, data: { title: 'Dashboard' } },
-  { path: 'news', component: NewsComponent, data: { title: 'Gerenciar Notícias' } },
-  { path: 'documents', component: DocumentsComponent, data: { title: 'Gerenciar Documentos' } },
-  { path: 'birthdays', component: BirthdaysComponent, data: { title: 'Gerenciar Aniversariantes' } },
-  { path: 'menu', component: MenuComponent, data: { title: 'Gerenciar Cardápio' } },
-  { path: 'events', component: EventsComponent, data: { title: 'Gerenciar Eventos' } },
-  { path: 'feedbacks', component: FeedbacksComponent, data: { title: 'Gerenciar Feedbacks' } },
-  { path: 'users', component: UsersComponent, data: { title: 'Gerenciar Usuários' } },
-  { path: 'banners', component: BannersComponent, data: { title: 'Gerenciar Banners' } },
-  { path: 'internal', component: InternalAnnouncementComponent, data: { title: 'Gerenciar Comunicados internos' } },
-  { path: 'chat', component: ChatComponent, data: { title: 'Chat Interno' } },
-  { path: 'courses-register', component: CourseRegistrationComponent, data: { title: 'Gerenciar Cursos' } },
-  { path: 'courses-tracking/:id', component: CourseTrackingComponent, data: { title: 'Rastreamento de Cursos' } },
-  { path: 'courses-view', component: CourseViewerComponent, data: { title: 'Meus Cursos' } },
-  { path: 'forms-register', component: FormsRegisterComponent, data: { title: 'Gerenciar Formulários' } },
-  { path: 'online-users', component: OnlineUsersComponent, data: { title: 'Gerenciar usuários onlines' } },
-  { path: 'cid', component: DiagnosticoComponent, data: { title: 'Processamento de Diagnóstico' } },
-  { path: 'atualizacao', component: AtualizacaoArquivosComponent, data: { title: 'Atualização de tabelas SIGTAP/TUSS' } },
+  { path: 'dashboard', component: DashboardComponent, canActivate: [RoleGuard], data: { title: 'Dashboard', roles: ['admin', 'editor', 'viewer'] } },
+  { path: 'news', component: NewsComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Notícias', roles: ['admin', 'editor'] } },
+  { path: 'documents', component: DocumentsComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Documentos', roles: ['admin', 'editor'] } },
+  { path: 'birthdays', component: BirthdaysComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Aniversariantes', roles: ['admin', 'editor'] } },
+  { path: 'menu', component: MenuComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Cardápio', roles: ['admin', 'editor'] } },
+  { path: 'events', component: EventsComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Eventos', roles: ['admin', 'editor'] } },
+  { path: 'feedbacks', component: FeedbacksComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Feedbacks', roles: ['admin', 'editor'] } },
+  { path: 'users', component: UsersComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Usuários', roles: ['admin'] } },
+  { path: 'banners', component: BannersComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Banners', roles: ['admin', 'editor'] } },
+  { path: 'internal', component: InternalAnnouncementComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Comunicados internos', roles: ['admin', 'editor'] } },
+  { path: 'chat', component: ChatComponent, canActivate: [RoleGuard], data: { title: 'Chat Interno', roles: ['admin', 'editor', 'viewer'] } },
+  { path: 'courses-register', component: CourseRegistrationComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Cursos', roles: ['admin', 'editor'] } },
+  { path: 'courses-tracking/:id', component: CourseTrackingComponent, canActivate: [RoleGuard], data: { title: 'Rastreamento de Cursos', roles: ['admin', 'editor'] } },
+  { path: 'courses-view', component: CourseViewerComponent, canActivate: [RoleGuard], data: { title: 'Meus Cursos', roles: ['admin', 'editor', 'viewer'] } },
+  { path: 'forms-register', component: FormsRegisterComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar Formulários', roles: ['admin', 'editor'] } },
+  { path: 'online-users', component: OnlineUsersComponent, canActivate: [RoleGuard], data: { title: 'Gerenciar usuários onlines', roles: ['admin']} },
+  { path: 'cid', component: DiagnosticoComponent, canActivate: [RoleGuard], data: { title: 'Processamento de Diagnóstico', roles: ['admin'] } },
+  { path: 'atualizacao', component: AtualizacaoArquivosComponent, canActivate: [RoleGuard], data: { title: 'Atualização de tabelas SIGTAP/TUSS', roles: ['admin'] } },
   { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
 ];
 

--- a/portalsantacasa.client/src/app/admin/components/admin-sidebar/admin-sidebar.component.html
+++ b/portalsantacasa.client/src/app/admin/components/admin-sidebar/admin-sidebar.component.html
@@ -39,7 +39,7 @@
         </div>
 
         <!-- Item com dropdown -->
-        <div *ngIf="item.children && canViewItem(item)"
+       <div *ngIf="item.children && getVisibleChildren(item).length > 0"
              class="nav-dropdown"
              [class.expanded]="expandedDropdowns.includes(item.id)">
 
@@ -61,7 +61,7 @@
           <!-- Conteúdo do Dropdown -->
           <div class="dropdown-content"
                *ngIf="expandedDropdowns.includes(item.id) && !isCollapsed">
-            <div *ngFor="let child of item.children"
+            <div *ngFor="let child of getVisibleChildren(item)"
                  class="nav-item dropdown-item"
                  [class.active]="activeItem === child.id"
                  (click)="navigateToItem(child)"
@@ -70,7 +70,7 @@
                 <i [class]="child.icon"></i>
               </div>
               <span class="nav-text">{{ child.label }}</span>
-              <span class="nav-badge"
+              <span class="nav-badge" 
                     *ngIf="getBadgeValue(child) && getBadgeValue(child)! > 0"
                     [class.birthday-badge]="child.badge === 'birthdaysBadge'">
                 {{ getBadgeValue(child) }}

--- a/portalsantacasa.client/src/app/admin/components/admin-sidebar/admin-sidebar.component.ts
+++ b/portalsantacasa.client/src/app/admin/components/admin-sidebar/admin-sidebar.component.ts
@@ -6,6 +6,7 @@ import { SidebarConfigService, SidebarPermissions } from './sidebar-config.servi
 import { ChatService } from '../../../core/services/chat.service';
 import { SidebarSection, SidebarItem } from './sidebar-config';
 import { OnlineService, OnlineUser } from '../../../core/services/online.service'; // Importar OnlineService
+import { AuthService } from '../../../core/services/auth.service';
 
 @Component({
   selector: 'app-admin-sidebar',
@@ -52,7 +53,8 @@ export class AdminSidebarComponent implements OnInit, OnDestroy {
     private sidebarConfigService: SidebarConfigService,
     private chatService: ChatService,
     private onlineService: OnlineService, // Injete OnlineService
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private authService: AuthService,
   ) { }
 
   ngOnInit(): void {
@@ -278,28 +280,19 @@ export class AdminSidebarComponent implements OnInit, OnDestroy {
   }
 
   canViewSection(section: SidebarSection): boolean {
-    if (section.type === 'public' && !this.permissions.canViewPublicArea) {
-      return false;
-    }
-    if (section.type === 'admin' && !this.permissions.canViewAdminArea) {
-      return false;
-    }
-    return true;
+    return section.items.some(item => this.canViewItem(item));
   }
-
   canViewItem(item: SidebarItem): boolean {
-    switch (item.id) {
-      case 'users':
-        return this.permissions.canManageUsers;
-      case 'news':
-      case 'events':
-      case 'banners':
-        return this.permissions.canManageContent;
-      case 'dashboard':
-        return this.permissions.canViewReports;
-      default:
-        return true;
+    const role = this.authService.getUserInfo('role')?.toLowerCase();
+
+    if (!item.roles || item.roles.length === 0) {
+      return true;
     }
+
+    return !!role && item.roles.map(r => r.toLowerCase()).includes(role);
+  }
+  getVisibleChildren(item: SidebarItem): SidebarItem[] {
+    return item.children?.filter(child => this.canViewItem(child)) || [];
   }
 
   getBadgeValue(item: SidebarItem): number | undefined {

--- a/portalsantacasa.client/src/app/admin/components/admin-sidebar/sidebar-config.ts
+++ b/portalsantacasa.client/src/app/admin/components/admin-sidebar/sidebar-config.ts
@@ -8,6 +8,7 @@ export interface SidebarItem {
   badgeValue?: number;
   children?: SidebarItem[];
   type: 'public' | 'admin';
+  roles?: string[];
 }
 
 export interface SidebarSection {
@@ -28,7 +29,8 @@ export const SIDEBAR_CONFIG: SidebarSection[] = [
         label: 'Início',
         icon: 'fas fa-home',
         routerLink: '/public/home',
-        type: 'public'
+        type: 'public',
+        roles: ['admin', 'editor', 'viewer']
       },
       //{
 	     //   id: 'chat',
@@ -36,14 +38,16 @@ export const SIDEBAR_CONFIG: SidebarSection[] = [
 	     //   icon: 'fas fa-comments',
 	     //   routerLink: '/admin/chat',
 	     //   badge: 'chat',
-	     //   type: 'public'
+      //    type: 'public',
+      //    roles: ['admin', 'editor', 'viewer']
       //},
       {
         id: 'my-courses',
         label: 'Meus Cursos',
         icon: 'fas fa-graduation-cap',
         routerLink: '/admin/courses-view',
-        type: 'public'
+        type: 'public',
+        roles: ['admin', 'editor', 'viewer']
       }
     ]
   },
@@ -57,7 +61,8 @@ export const SIDEBAR_CONFIG: SidebarSection[] = [
         label: 'Dashboard',
         icon: 'fas fa-tachometer-alt',
         routerLink: '/admin/dashboard',
-        type: 'admin'
+        type: 'admin',
+        roles: ['admin', 'editor', 'viewer']
       },
       {
         id: 'communication',
@@ -72,14 +77,16 @@ export const SIDEBAR_CONFIG: SidebarSection[] = [
             routerLink: '/admin/news',
             queryParams: { quality: false },
             badge: 'newsBadge',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           },
           {
             id: 'comunicados',
             label: 'Comunicados',
             icon: 'fas fa-bullhorn',
             routerLink: '/admin/internal',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           },
           {
             id: 'qualityMinute',
@@ -87,7 +94,8 @@ export const SIDEBAR_CONFIG: SidebarSection[] = [
             icon: 'fas fa-stopwatch',
             routerLink: '/admin/news',
             queryParams: { quality: true },
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           },
           {
             id: 'events',
@@ -95,7 +103,8 @@ export const SIDEBAR_CONFIG: SidebarSection[] = [
             icon: 'fas fa-calendar-alt',
             routerLink: '/admin/events',
             badge: 'eventsBadge',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           },
           {
             id: 'birthdays',
@@ -103,21 +112,24 @@ export const SIDEBAR_CONFIG: SidebarSection[] = [
             icon: 'fas fa-birthday-cake',
             routerLink: '/admin/birthdays',
             badge: 'birthdaysBadge',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           },
           {
             id: 'banners',
             label: 'Banners',
             icon: 'fas fa-images',
             routerLink: '/admin/banners',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           },
           {
             id: 'forms',
             label: 'Formulários',
             icon: 'fas fa-file-alt',
             routerLink: '/admin/forms-register',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           }
         ]
       },
@@ -132,28 +144,32 @@ export const SIDEBAR_CONFIG: SidebarSection[] = [
             label: 'Cardápio',
             icon: 'fas fa-utensils',
             routerLink: '/admin/menu',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           },
           {
             id: 'feedbacks',
             label: 'Sugestões',
             icon: 'fas fa-comments',
             routerLink: '/admin/feedbacks',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           },
           {
             id: 'diagnosticos',
             label: 'Diagnósticos',
             icon: 'fas fa-notes-medical',
             routerLink: '/admin/cid',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin']
           },
           {
             id: 'atualizacao',
             label: 'Atualização',
             icon: 'fas fa-sync-alt',
             routerLink: '/admin/atualizacao',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin']
           }
         ]
       },
@@ -168,21 +184,24 @@ export const SIDEBAR_CONFIG: SidebarSection[] = [
             label: 'Video Aulas',
             icon: 'fas fa-video',
             routerLink: '/admin/courses-register',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           },
           {
             id: 'documents',
             label: 'Documentos',
             icon: 'fas fa-file-alt',
             routerLink: '/admin/documents',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin', 'editor']
           },
           {
             id: 'users',
             label: 'Usuários',
             icon: 'fas fa-users',
             routerLink: '/admin/users',
-            type: 'admin'
+            type: 'admin',
+            roles: ['admin']
           }
         ]
       }

--- a/portalsantacasa.client/src/app/app-routing.module.ts
+++ b/portalsantacasa.client/src/app/app-routing.module.ts
@@ -33,15 +33,16 @@ const routes: Routes = [
     path: 'admin',
     component: AdminLayoutComponent,
     canActivate: [AuthGuard, RoleGuard],
-    data: { expectedRole: 'admin' },
+    data: {
+      roles: ['admin', 'editor', 'viewer']
+    },
     children: [
       {
         path: '',
         loadChildren: () => import('./admin/admin.module').then(m => m.AdminModule)
       }
     ]
-  },
-  { path: '**', redirectTo: '', pathMatch: 'full' }
+  }
 ];
 
 @NgModule({

--- a/portalsantacasa.client/src/app/core/guards/role.guard.ts
+++ b/portalsantacasa.client/src/app/core/guards/role.guard.ts
@@ -7,11 +7,16 @@ export class RoleGuard implements CanActivate {
   constructor(private auth: AuthService, private router: Router) { }
 
   canActivate(route: ActivatedRouteSnapshot): boolean {
-    const expectedRole = route.data['expectedRole'];
-    const userRole = this.auth.getUserInfo('role');
 
-    if (!userRole || userRole.toLowerCase() !== String(expectedRole).toLowerCase()) {
-      this.router.navigate(['/unauthorized']);
+    const roles = route.data['roles'] as string[];
+    const userRole = this.auth.getUserInfo('role');
+    console.log(userRole)
+    if (!userRole) {
+      return false;
+    }
+
+    if (!roles.includes(userRole.toLowerCase())) {
+      this.router.navigate(['/']);
       return false;
     }
 


### PR DESCRIPTION
Introduce role-based authorization across the admin area: add RoleGuard to admin routing and per-route role metadata, update app routing to include RoleGuard and roles for the admin layout. Extend sidebar config with roles for each item and update the admin-sidebar component to use AuthService to filter visible items/children (added getVisibleChildren) and only render dropdowns with visible children; also adjusted badge rendering. Update RoleGuard to read a roles array from route data, validate against the current user's role and redirect unauthorized users to the root.