### PR TITLE
Remove debug log and add migration connection string

### DIFF
--- a/PortalSantaCasa.Server/appsettings.Development.json
+++ b/PortalSantaCasa.Server/appsettings.Development.json
@@ -22,6 +22,7 @@
   },
   "ConnectionStrings": {
     "PortalSclConnectionString": "Server=localhost;Database=PortalScl;User Id=root;Password=1234;Port=3306;CharSet=utf8mb4;"
+    //"PortalSclConnectionString": "Server=intranet.santacasalorena.org.br;Port=3307;Database=db_intranet-santacasalorena-org-br;User=usr_app-santacasalorena-org-br;Password=BUm50Q4V-K7_9xA;CharSet=utf8mb4;" PARA RODAR MIGRATIONS
   },
   "RabbitMQ": {
     "Host": "localhost",

--- a/portalsantacasa.client/src/app/core/guards/role.guard.ts
+++ b/portalsantacasa.client/src/app/core/guards/role.guard.ts
@@ -10,7 +10,6 @@ export class RoleGuard implements CanActivate {
 
     const roles = route.data['roles'] as string[];
     const userRole = this.auth.getUserInfo('role');
-    console.log(userRole)
     if (!userRole) {
       return false;
     }


### PR DESCRIPTION
Remove console.log debug statement from role guard. Add commented-out connection string for running migrations locally against the production database.