### PR TITLE
Add content tracking to public access logs

### DIFF
--- a/PortalSantaCasa.Server/Controllers/PublicAccessLogController.cs
+++ b/PortalSantaCasa.Server/Controllers/PublicAccessLogController.cs
@@ -34,7 +34,7 @@ namespace PortalSantaCasa.Server.Controllers
                 Name = dto.Name.Trim(),
                 RE = dto.RE.Trim(),
                 Sector = dto.Sector.Trim(),
-                Page = NormalizePage(dto.Page),
+                Page = FormatPage(dto.Page, dto.ContentId, dto.ContentTitle),
                 AccessedAt = DateTimeOffset.UtcNow,
                 IpAddress = GetClientIpAddress(),
                 UserAgent = Request.Headers["User-Agent"].ToString()
@@ -81,7 +81,9 @@ namespace PortalSantaCasa.Server.Controllers
             if (!string.IsNullOrWhiteSpace(effectivePageType))
             {
                 var pageAliases = GetPageAliases(effectivePageType);
-                query = query.Where(log => pageAliases.Contains(log.Page));
+                query = query.Where(log =>
+                    pageAliases.Contains(log.Page) ||
+                    log.Page.StartsWith(effectivePageType + "::"));
             }
 
             if (effectiveStartDate.HasValue)
@@ -101,22 +103,13 @@ namespace PortalSantaCasa.Server.Controllers
             }
 
             var total = await query.CountAsync();
-            var logs = await query
+            var logs = (await query
                 .OrderByDescending(log => log.AccessedAt)
                 .Skip((currentPage - 1) * perPage)
                 .Take(perPage)
-                .Select(log => new PublicAccessLogResponseDto
-                {
-                    Id = log.Id,
-                    Name = log.Name,
-                    RE = log.RE,
-                    Sector = log.Sector,
-                    Page = log.Page,
-                    AccessedAt = log.AccessedAt,
-                    IpAddress = log.IpAddress,
-                    UserAgent = log.UserAgent
-                })
-                .ToListAsync();
+                .ToListAsync())
+                .Select(ToResponse)
+                .ToList();
 
             return Ok(new
             {
@@ -142,13 +135,17 @@ namespace PortalSantaCasa.Server.Controllers
 
         private static PublicAccessLogResponseDto ToResponse(PublicAccessLog log)
         {
+            var pageDetails = ParsePage(log.Page);
+
             return new PublicAccessLogResponseDto
             {
                 Id = log.Id,
                 Name = log.Name,
                 RE = log.RE,
                 Sector = log.Sector,
-                Page = log.Page,
+                Page = pageDetails.Page,
+                ContentId = pageDetails.ContentId,
+                ContentTitle = pageDetails.ContentTitle,
                 AccessedAt = log.AccessedAt,
                 IpAddress = log.IpAddress,
                 UserAgent = log.UserAgent
@@ -157,7 +154,9 @@ namespace PortalSantaCasa.Server.Controllers
 
         private static string NormalizePage(string? page)
         {
-            var normalized = page?.Trim().ToLowerInvariant();
+            var normalized = page?.Split("::", 2, StringSplitOptions.None)[0]
+                .Trim()
+                .ToLowerInvariant();
 
             return normalized switch
             {
@@ -166,6 +165,34 @@ namespace PortalSantaCasa.Server.Controllers
                 "qualidade" or "minuto de qualidade" => "qualidade",
                 _ => normalized ?? string.Empty
             };
+        }
+
+        private static string FormatPage(string page, int? contentId, string? contentTitle)
+        {
+            var normalizedPage = NormalizePage(page);
+            var normalizedTitle = contentTitle?.Trim();
+
+            if (!contentId.HasValue || string.IsNullOrWhiteSpace(normalizedTitle))
+            {
+                return normalizedPage;
+            }
+
+            return $"{normalizedPage}::{contentId.Value}::{normalizedTitle}";
+        }
+
+        private static (string Page, int? ContentId, string? ContentTitle) ParsePage(string page)
+        {
+            var parts = page.Split("::", 3, StringSplitOptions.None);
+            var normalizedPage = NormalizePage(parts[0]);
+
+            if (parts.Length < 3 ||
+                !int.TryParse(parts[1], out var contentId) ||
+                string.IsNullOrWhiteSpace(parts[2]))
+            {
+                return (normalizedPage, null, null);
+            }
+
+            return (normalizedPage, contentId, parts[2]);
         }
 
         private static string[] GetPageAliases(string pageType)

--- a/PortalSantaCasa.Server/DTOs/PublicAccessLogDto.cs
+++ b/PortalSantaCasa.Server/DTOs/PublicAccessLogDto.cs
@@ -6,6 +6,8 @@ namespace PortalSantaCasa.Server.DTOs
         public string RE { get; set; } = null!;
         public string Sector { get; set; } = null!;
         public string Page { get; set; } = null!;
+        public int? ContentId { get; set; }
+        public string? ContentTitle { get; set; }
     }
 
     public class PublicAccessLogResponseDto
@@ -15,6 +17,8 @@ namespace PortalSantaCasa.Server.DTOs
         public string RE { get; set; } = null!;
         public string Sector { get; set; } = null!;
         public string Page { get; set; } = null!;
+        public int? ContentId { get; set; }
+        public string? ContentTitle { get; set; }
         public DateTimeOffset AccessedAt { get; set; }
         public string? IpAddress { get; set; }
         public string? UserAgent { get; set; }

--- a/portalsantacasa.client/src/app/admin/pages/public-access-log/public-access-log.component.html
+++ b/portalsantacasa.client/src/app/admin/pages/public-access-log/public-access-log.component.html
@@ -80,6 +80,7 @@
             <th>RE</th>
             <th>Setor</th>
             <th>Página</th>
+            <th>Conteúdo acessado</th>
           </tr>
         </thead>
         <tbody>
@@ -89,9 +90,10 @@
             <td>{{ log.re }}</td>
             <td>{{ log.sector }}</td>
             <td><span class="page-badge">{{ getPageLabel(log.page) }}</span></td>
+            <td>{{ getContentLabel(log) }}</td>
           </tr>
           <tr *ngIf="logs.length === 0">
-            <td colspan="5" class="empty-row">Nenhum acesso encontrado.</td>
+            <td colspan="6" class="empty-row">Nenhum acesso encontrado.</td>
           </tr>
         </tbody>
       </table>

--- a/portalsantacasa.client/src/app/admin/pages/public-access-log/public-access-log.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/public-access-log/public-access-log.component.ts
@@ -98,13 +98,14 @@ export class PublicAccessLogComponent implements OnInit {
     this.loadFilteredLogsForExport().subscribe({
       next: (logs) => {
         const rows = [
-          ['Data/Hora', 'Nome', 'RE', 'Setor', 'Página'],
+          ['Data/Hora', 'Nome', 'RE', 'Setor', 'Página', 'Conteúdo'],
           ...logs.map(log => [
             this.formatDateTime(log.accessedAt),
             log.name,
             log.re,
             log.sector,
-            this.getPageLabel(log.page)
+            this.getPageLabel(log.page),
+            this.getContentLabel(log)
           ])
         ];
         const csv = rows
@@ -140,13 +141,14 @@ export class PublicAccessLogComponent implements OnInit {
 
         autoTable(doc, {
           startY: 38,
-          head: [['Data/Hora', 'Nome', 'RE', 'Setor', 'Página']],
+          head: [['Data/Hora', 'Nome', 'RE', 'Setor', 'Página', 'Conteúdo']],
           body: logs.map(log => [
             this.formatDateTime(log.accessedAt),
             log.name,
             log.re,
             log.sector,
-            this.getPageLabel(log.page)
+            this.getPageLabel(log.page),
+            this.getContentLabel(log)
           ]),
           styles: { fontSize: 8, cellPadding: 2 },
           headStyles: { fillColor: [34, 188, 238] }
@@ -223,6 +225,16 @@ export class PublicAccessLogComponent implements OnInit {
       hour: '2-digit',
       minute: '2-digit'
     });
+  }
+
+  getContentLabel(log: PublicAccessLog): string {
+    if (!log.contentTitle?.trim()) {
+      return '-';
+    }
+
+    return log.contentId
+      ? `#${log.contentId} - ${log.contentTitle}`
+      : log.contentTitle;
   }
 
   private escapeCsvCell(value: string): string {

--- a/portalsantacasa.client/src/app/models/public-access-log.model.ts
+++ b/portalsantacasa.client/src/app/models/public-access-log.model.ts
@@ -3,6 +3,8 @@ export interface PublicAccessLogCreate {
   re: string;
   sector: string;
   page: string;
+  contentId?: number;
+  contentTitle?: string;
 }
 
 export interface PublicAccessLog {
@@ -11,6 +13,8 @@ export interface PublicAccessLog {
   re: string;
   sector: string;
   page: string;
+  contentId?: number;
+  contentTitle?: string;
   accessedAt: string;
   ipAddress?: string;
   userAgent?: string;

--- a/portalsantacasa.client/src/app/pages/internal-announcement-detail/internal-announcement-detail.component.html
+++ b/portalsantacasa.client/src/app/pages/internal-announcement-detail/internal-announcement-detail.component.html
@@ -1,6 +1,8 @@
 <div class="standard-container">
   <app-public-access-log-modal
     page="Comunicados"
+    [contentId]="announcement?.id"
+    [contentTitle]="announcement?.title || ''"
     [isOpen]="isAccessLogModalOpen"
     (registered)="onAccessLogRegistered()"
     (closed)="onAccessLogClosed()">

--- a/portalsantacasa.client/src/app/pages/internal-announcement-detail/internal-announcement-detail.component.ts
+++ b/portalsantacasa.client/src/app/pages/internal-announcement-detail/internal-announcement-detail.component.ts
@@ -176,7 +176,9 @@ export class InternalAnnouncementDetailComponent implements OnInit {
       name: identity.name,
       re: identity.re,
       sector: identity.sector,
-      page: 'Comunicados'
+      page: 'Comunicados',
+      contentId: this.announcement.id,
+      contentTitle: this.announcement.title
     }).subscribe({
       next: () => {
         this.accessRegisteredForId = this.announcement?.id;

--- a/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.html
+++ b/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.html
@@ -1,6 +1,8 @@
 <div class="news-detail-container">
   <app-public-access-log-modal
     [page]="accessLogPage"
+    [contentId]="news.id"
+    [contentTitle]="news.title"
     [isOpen]="isAccessLogModalOpen"
     (registered)="onAccessLogRegistered()"
     (closed)="onAccessLogClosed()">

--- a/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.ts
+++ b/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.ts
@@ -152,7 +152,9 @@ export class NewsDetailComponent implements OnInit {
       name: identity.name,
       re: identity.re,
       sector: identity.sector,
-      page: this.accessLogPage
+      page: this.accessLogPage,
+      contentId: this.news.id,
+      contentTitle: this.news.title
     }).subscribe({
       next: () => {
         this.accessRegisteredForId = this.news.id;

--- a/portalsantacasa.client/src/app/shared/components/public-access-log-modal/public-access-log-modal.component.ts
+++ b/portalsantacasa.client/src/app/shared/components/public-access-log-modal/public-access-log-modal.component.ts
@@ -12,6 +12,8 @@ import { DEPARTMENTS } from '../../constants/departments.constants';
 })
 export class PublicAccessLogModalComponent {
   @Input() page = '';
+  @Input() contentId?: number;
+  @Input() contentTitle = '';
   @Input() isOpen = false;
   @Output() registered = new EventEmitter<void>();
   @Output() closed = new EventEmitter<void>();
@@ -58,7 +60,9 @@ export class PublicAccessLogModalComponent {
       name: this.form.name.trim(),
       re: this.form.re.trim(),
       sector: this.form.sector.trim(),
-      page: this.page.trim()
+      page: this.page.trim(),
+      contentId: this.contentId,
+      contentTitle: this.contentTitle.trim() || undefined
     }).subscribe({
       next: () => {
         this.pointsService.saveIdentity({
@@ -83,7 +87,9 @@ export class PublicAccessLogModalComponent {
       name: '',
       re: '',
       sector: '',
-      page: ''
+      page: '',
+      contentId: undefined,
+      contentTitle: undefined
     };
   }
 }


### PR DESCRIPTION
Enhance public access logging to capture which specific content (news, announcements, etc.) was accessed. Stores content ID and title alongside page information using a formatted page string (page::contentId::title). Updates the admin dashboard to display content details in the access log table and export formats (CSV/PDF).