### PR TITLE
Remove Server.Tests project from solution

### DIFF
--- a/PortalSantaCasa.sln
+++ b/PortalSantaCasa.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 18
-VisualStudioVersion = 18.2.11408.102 d18.0
+VisualStudioVersion = 18.2.11408.102
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{54A90642-561A-4BB1-A94E-469ADEE60C69}") = "portalsantacasa.client", "portalsantacasa.client\portalsantacasa.client.esproj", "{71FF92B4-9906-13B6-C26D-3444B0BFA298}"
 EndProject
@@ -10,8 +10,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PortalSantaCasa.Realtime", "PortalSantaCasa.Realtime\PortalSantaCasa.Realtime.csproj", "{45393656-0B2D-4B8E-82DB-EA85A1253B96}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PortalSantaCasa.Shared", "PortalSantaCasa.Shared\PortalSantaCasa.Shared.csproj", "{8DEEA23A-9D7D-4AB0-9BA7-58133686658B}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PortalSantaCasa.Server.Tests", "PortalSantaCasa.Server.Tests\PortalSantaCasa.Server.Tests.csproj", "{54E9F872-3E55-4B55-9169-447F51F8BB91}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -37,10 +35,6 @@ Global
 		{8DEEA23A-9D7D-4AB0-9BA7-58133686658B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8DEEA23A-9D7D-4AB0-9BA7-58133686658B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8DEEA23A-9D7D-4AB0-9BA7-58133686658B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{54E9F872-3E55-4B55-9169-447F51F8BB91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{54E9F872-3E55-4B55-9169-447F51F8BB91}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{54E9F872-3E55-4B55-9169-447F51F8BB91}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{54E9F872-3E55-4B55-9169-447F51F8BB91}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Remove the PortalSantaCasa.Server.Tests project entry and its associated configuration mappings from PortalSantaCasa.sln. Also clean up the VisualStudioVersion line by removing an extraneous suffix. This keeps the solution file consistent with the current project set.