### PR TITLE
Remove secrets and allow anonymous fallback

### DIFF
--- a/PortalSantaCasa.Realtime/appsettings.Production.json
+++ b/PortalSantaCasa.Realtime/appsettings.Production.json
@@ -13,12 +13,10 @@
   "RabbitMQ": {
     "Host": "rabbitmq",
     "User": "intranet",
-    "Password": "BUm50Q4V-K7_9xA",
     "VirtualHost": "/",
     "UseSsl": false
   },
   "Jwt": {
-    "Key": "-_N!8c3jwuh,3BTz6#3^PfPdJsM8aY3FsP)mtbb-Sb7|Kc1sr8|gf4r{zJ>JD{w/d/H={Aze!7TxB;[gKBVXT.OraDbpJfr+U]G6hWfSWTA6D/WpuKOJIk+V^jAAR{.$HG%uYw?I#UaUClctxChw>Jqw9DVNXxJ+0t&$F.g+)4GtB,RnvDh$^%/a&.a]bjV_[#Q.}vhC&=#Zc]4O+tmam/Jc?Go-4{/fEpM]<SSuV#svyPu?kBtu_Z?Th{yN)UmZ-SPzIYBM[5[!ih7GP/Gy%hp?RD<6=k9|!z;.h{*nuTy[KLpGQTiYk^wjZPmJ3kf7HR;yg,C*S0s={hs?QnK9NF9dK5f6E||q*M?!^Al8$Zuh|ewWe>pbs#o;IZla@H{E;[7(K80Z)Z1mZ4iKfeXM%?&H>S=4{?/oe[jqBt%0$R6GtEnAfX%$-XH6OfXBwq:oAM5=nlJ)0CUrX!JZ3E%<+XyAy]=r{V{$X.f=n?[k}Wm<yDq/eSZ/bL(lT1n]_QAu",
     "Issuer": "intranet.santacasalorena.org.br",
     "Audience": "intranet.santacasalorena.org.br"
   }

--- a/PortalSantaCasa.Server/Program.cs
+++ b/PortalSantaCasa.Server/Program.cs
@@ -351,7 +351,7 @@ app.MapFallbackToFile("index.html", new StaticFileOptions
 {
     FileProvider = new PhysicalFileProvider(
         Path.Combine(Directory.GetCurrentDirectory(), "wwwroot", "browser"))
-});
+}).AllowAnonymous();
 
 if (app.Configuration.GetValue<bool>("Database:ApplyMigrationsOnStartup"))
 {

--- a/PortalSantaCasa.Server/appsettings.Production.json
+++ b/PortalSantaCasa.Server/appsettings.Production.json
@@ -4,8 +4,6 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
       "Microsoft.AspNetCore.SignalR": "Warning"
-      //"Microsoft.AspNetCore.Authentication": "Debug",
-      //"Microsoft.AspNetCore.Hosting": "Information"
     }
   },
   "Kestrel": {
@@ -24,19 +22,13 @@
       "http://docker-w3.sp.santacasalorena.org.br:8086"
     ]
   },
-
   "Jwt": {
-    "Key": "-_N!8c3jwuh,3BTz6#3^PfPdJsM8aY3FsP)mtbb-Sb7|Kc1sr8|gf4r{zJ>JD{w/d/H={Aze!7TxB;[gKBVXT.OraDbpJfr+U]G6hWfSWTA6D/WpuKOJIk+V^jAAR{.$HG%uYw?I#UaUClctxChw>Jqw9DVNXxJ+0t&$F.g+)4GtB,RnvDh$^%/a&.a]bjV_[#Q.}vhC&=#Zc]4O+tmam/Jc?Go-4{/fEpM]<SSuV#svyPu?kBtu_Z?Th{yN)UmZ-SPzIYBM[5[!ih7GP/Gy%hp?RD<6=k9|!z;.h{*nuTy[KLpGQTiYk^wjZPmJ3kf7HR;yg,C*S0s={hs?QnK9NF9dK5f6E||q*M?!^Al8$Zuh|ewWe>pbs#o;IZla@H{E;[7(K80Z)Z1mZ4iKfeXM%?&H>S=4{?/oe[jqBt%0$R6GtEnAfX%$-XH6OfXBwq:oAM5=nlJ)0CUrX!JZ3E%<+XyAy]=r{V{$X.f=n?[k}Wm<yDq/eSZ/bL(lT1n]_QAu",
     "Issuer": "intranet.santacasalorena.org.br",
     "Audience": "intranet.santacasalorena.org.br"
-  },
-  "ConnectionStrings": {
-    "PortalSclConnectionString": "Server=mysql80;Port=3306;Database=db_intranet-santacasalorena-org-br;User=usr_app-santacasalorena-org-br;Password=BUm50Q4V-K7_9xA;CharSet=utf8mb4;"
   },
   "RabbitMQ": {
     "Host": "rabbitmq",
     "User": "intranet",
-    "Password": "BUm50Q4V-K7_9xA",
     "VirtualHost": "/",
     "UseSsl": false
   },


### PR DESCRIPTION
Remove hard-coded secrets from production settings and allow unauthenticated SPA fallback. Removed Jwt Key, RabbitMQ password and the DB connection string from PortalSantaCasa.Realtime/appsettings.Production.json and PortalSantaCasa.Server/appsettings.Production.json (also removed two commented logging lines). In Program.cs, appended .AllowAnonymous() to the MapFallbackToFile call so the SPA fallback can be served without authentication. Secrets should be provided via environment variables or a secret manager instead of being committed.