### PR TITLE
Add management endpoints for news and announcements

### DIFF
--- a/PortalSantaCasa.Server/Controllers/InternalAnnouncementController.cs
+++ b/PortalSantaCasa.Server/Controllers/InternalAnnouncementController.cs
@@ -29,11 +29,10 @@ namespace PortalSantaCasa.Server.Controllers
         public async Task<IActionResult> GetAllPaginated([FromQuery] int page = 1, [FromQuery] int perPage = 10,
             [FromQuery] string status = "all")
         {
-            var effectiveStatus = IsContentManager() ? status : "public";
-            var ownerScope = IsContentManager() ? GetOwnerScope() : null;
-            var items = await _service.GetAllPaginatedAsync(page, perPage, effectiveStatus, ownerScope);
+            const string effectiveStatus = "public";
+            var items = await _service.GetAllPaginatedAsync(page, perPage, effectiveStatus);
 
-            var totalCount = await _service.GetTotalCountAsync(effectiveStatus, ownerScope);
+            var totalCount = await _service.GetTotalCountAsync(effectiveStatus);
 
             var totalPages = (int)Math.Ceiling(totalCount / (double)perPage);
 
@@ -47,25 +46,47 @@ namespace PortalSantaCasa.Server.Controllers
             });
         }
 
+        [Authorize(Roles = "admin,Admin,editor,Editor,superadmin,SuperAdmin")]
+        [HttpGet("management/paginated")]
+        public async Task<IActionResult> GetManagementPaginated([FromQuery] int page = 1, [FromQuery] int perPage = 10,
+            [FromQuery] string status = "all")
+        {
+            var ownerScope = GetOwnerScope();
+            var items = await _service.GetAllPaginatedAsync(page, perPage, status, ownerScope);
+            var totalCount = await _service.GetTotalCountAsync(status, ownerScope);
+
+            return Ok(new
+            {
+                items,
+                currentPage = page,
+                perPage,
+                totalPages = (int)Math.Ceiling(totalCount / (double)perPage),
+                totalCount
+            });
+        }
+
         [AllowAnonymous]
         [HttpGet("{id:int}")]
         public async Task<IActionResult> GetById(int id)
         {
             var announcement = await _service.GetByIdAsync(id);
-            var ownerScope = IsContentManager() ? GetOwnerScope() : null;
             var now = DateTimeOffset.UtcNow;
             var isPubliclyVisible =
                 announcement is { IsActive: true } &&
                 announcement.PublishDate <= now &&
                 (!announcement.ExpirationDate.HasValue || announcement.ExpirationDate > now);
-            if (announcement == null ||
-                (!isPubliclyVisible &&
-                 (!IsContentManager() ||
-                  (ownerScope.HasValue && announcement.UserId != ownerScope.Value))))
-            {
-                return NotFound();
-            }
-            return Ok(announcement);
+            return isPubliclyVisible ? Ok(announcement) : NotFound();
+        }
+
+        [Authorize(Roles = "admin,Admin,editor,Editor,superadmin,SuperAdmin")]
+        [HttpGet("management/{id:int}")]
+        public async Task<IActionResult> GetManagementById(int id)
+        {
+            var announcement = await _service.GetByIdAsync(id);
+            var ownerScope = GetOwnerScope();
+            return announcement != null && (!ownerScope.HasValue || announcement.UserId == ownerScope.Value)
+                ? Ok(announcement)
+                : NotFound();
         }
 
         [Authorize(Roles = "admin,Admin")]
@@ -114,12 +135,6 @@ namespace PortalSantaCasa.Server.Controllers
 
             throw new UnauthorizedAccessException("Usuário não autenticado ou ID de usuário não encontrado.");
         }
-
-        private bool IsContentManager() =>
-            User.Identity?.IsAuthenticated == true &&
-            (User.IsInRole("admin") || User.IsInRole("Admin") ||
-             User.IsInRole("editor") || User.IsInRole("Editor") ||
-             User.IsInRole("superadmin") || User.IsInRole("SuperAdmin"));
 
         private int? GetOwnerScope() =>
             User.IsInRole("superadmin") || User.IsInRole("SuperAdmin")

--- a/PortalSantaCasa.Server/Controllers/NewsController.cs
+++ b/PortalSantaCasa.Server/Controllers/NewsController.cs
@@ -30,15 +30,30 @@ namespace PortalSantaCasa.Server.Controllers
         public async Task<IActionResult> GetAllPaginated([FromQuery] int page = 1, [FromQuery] int perPage = 10,
             [FromQuery] bool? isQualityMinute = null, [FromQuery] string status = "all")
         {
-            var effectiveStatus = IsContentManager() ? status : "active";
-            var ownerScope = IsContentManager() ? GetOwnerScope() : null;
-            var result = await _service.GetAllPaginatedAsync(page, perPage, isQualityMinute, effectiveStatus, ownerScope);
+            const string effectiveStatus = "active";
+            var result = await _service.GetAllPaginatedAsync(page, perPage, isQualityMinute, effectiveStatus);
             return Ok(new
             {
                 currentPage = page,
                 perPage,
                 news = result,
-                pages = (int)Math.Ceiling(await _service.GetTotalCountAsync(isQualityMinute, effectiveStatus, ownerScope) / (double)perPage)
+                pages = (int)Math.Ceiling(await _service.GetTotalCountAsync(isQualityMinute, effectiveStatus) / (double)perPage)
+            });
+        }
+
+        [Authorize(Roles = "admin,Admin,editor,Editor,superadmin,SuperAdmin")]
+        [HttpGet("management/paginated")]
+        public async Task<IActionResult> GetManagementPaginated([FromQuery] int page = 1, [FromQuery] int perPage = 10,
+            [FromQuery] bool? isQualityMinute = null, [FromQuery] string status = "all")
+        {
+            var ownerScope = GetOwnerScope();
+            var result = await _service.GetAllPaginatedAsync(page, perPage, isQualityMinute, status, ownerScope);
+            return Ok(new
+            {
+                currentPage = page,
+                perPage,
+                news = result,
+                pages = (int)Math.Ceiling(await _service.GetTotalCountAsync(isQualityMinute, status, ownerScope) / (double)perPage)
             });
         }
 
@@ -47,15 +62,18 @@ namespace PortalSantaCasa.Server.Controllers
         public async Task<IActionResult> GetById(int id)
         {
             var result = await _service.GetByIdAsync(id);
-            var ownerScope = IsContentManager() ? GetOwnerScope() : null;
-            if (result == null ||
-                (!result.IsActive &&
-                 (!IsContentManager() ||
-                  (ownerScope.HasValue && result.UserId != ownerScope.Value))))
-            {
-                return NotFound();
-            }
-            return Ok(result);
+            return result is { IsActive: true } ? Ok(result) : NotFound();
+        }
+
+        [Authorize(Roles = "admin,Admin,editor,Editor,superadmin,SuperAdmin")]
+        [HttpGet("management/{id:int}")]
+        public async Task<IActionResult> GetManagementById(int id)
+        {
+            var result = await _service.GetByIdAsync(id);
+            var ownerScope = GetOwnerScope();
+            return result != null && (!ownerScope.HasValue || result.UserId == ownerScope.Value)
+                ? Ok(result)
+                : NotFound();
         }
 
         [Authorize(Roles = "admin,Admin")]
@@ -90,11 +108,7 @@ namespace PortalSantaCasa.Server.Controllers
         [HttpGet("search")]
         public async Task<IActionResult> Search([FromQuery] string q)
         {
-            var isManager = IsContentManager();
-            var result = await _service.SearchAsync(
-                q,
-                isManager ? GetOwnerScope() : null,
-                activeOnly: !isManager);
+            var result = await _service.SearchAsync(q, activeOnly: true);
             return Ok(result);
         }
 
@@ -116,12 +130,6 @@ namespace PortalSantaCasa.Server.Controllers
 
             throw new UnauthorizedAccessException("Usuário não autenticado ou ID de usuário não encontrado.");
         }
-
-        private bool IsContentManager() =>
-            User.Identity?.IsAuthenticated == true &&
-            (User.IsInRole("admin") || User.IsInRole("Admin") ||
-             User.IsInRole("editor") || User.IsInRole("Editor") ||
-             User.IsInRole("superadmin") || User.IsInRole("SuperAdmin"));
 
         private int? GetOwnerScope() =>
             User.IsInRole("superadmin") || User.IsInRole("SuperAdmin")

--- a/portalsantacasa.client/src/app/admin/pages/internal-announcement/internal-announcement.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/internal-announcement/internal-announcement.component.ts
@@ -97,7 +97,7 @@ export class InternalAnnouncementComponent implements OnInit {
   // 📌 Carregar comunicados
   // =====================
   loadInternals(page: number = 1): void {
-    this.internalService.getPaginated(page, this.perPage).subscribe({
+    this.internalService.getManagementPaginated(page, this.perPage).subscribe({
       next: (res) => {
         this.internals = res.items;
         this.filteredInternals = [...this.internals];
@@ -134,7 +134,7 @@ export class InternalAnnouncementComponent implements OnInit {
   setStatusFilter(filter: 'all' | 'active' | 'inactive') {
     this.statusFilter = filter;
 
-    this.internalService.getPaginated(1, this.perPage, filter).subscribe({
+    this.internalService.getManagementPaginated(1, this.perPage, filter).subscribe({
       next: (res) => {
         this.internals = res.items;
 
@@ -174,7 +174,7 @@ export class InternalAnnouncementComponent implements OnInit {
     this.modalTitle = this.isEdit ? 'Editar Comunicado Interno' : 'Novo Comunicado Interno';
 
     if (id) {
-      this.internalService.getById(id).subscribe({
+      this.internalService.getManagementById(id).subscribe({
         next: (internal) => {
           this.internalData = { ...internal };
           // Garantir que o conteúdo não seja nulo

--- a/portalsantacasa.client/src/app/admin/pages/news/news.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/news/news.component.ts
@@ -119,7 +119,7 @@ export class NewsComponent implements OnInit {
   // 📌 CRUD
   // =====================
   loadNews(page: number = this.currentPage): void {
-    this.newsService.getNewsPaginated(page, this.perPage, this.isQualityMinute).subscribe({
+    this.newsService.getManagementNewsPaginated(page, this.perPage, this.isQualityMinute).subscribe({
       next: (data) => {
         this.newsList = data.news
           .filter(n => n.department == this.department)
@@ -264,7 +264,7 @@ export class NewsComponent implements OnInit {
     this.modalTitle = this.isEdit ? `Editar ${this.newsTerm}` : `Nova ${this.newsTerm}`;
 
     if (newsId) {
-      this.newsService.getNewsById(newsId).subscribe({
+      this.newsService.getManagementNewsById(newsId).subscribe({
         next: (news) => {
           this.newsData = {
             ...news,
@@ -308,7 +308,7 @@ export class NewsComponent implements OnInit {
   setStatusFilter(filter: 'all' | 'active' | 'inactive') {
     this.statusFilter = filter;
 
-    this.newsService.getNewsPaginated(1, this.perPage, this.isQualityMinute, filter).subscribe({
+    this.newsService.getManagementNewsPaginated(1, this.perPage, this.isQualityMinute, filter).subscribe({
       next: data => {
         this.newsList = data.news.filter(n => n.department == this.department).map(n => ({
           ...n,

--- a/portalsantacasa.client/src/app/core/services/internal-announcement.service.ts
+++ b/portalsantacasa.client/src/app/core/services/internal-announcement.service.ts
@@ -18,8 +18,18 @@ export class InternalAnnouncementService {
       .pipe(catchError(this.handleError));
   }
 
+  getManagementPaginated(page: number, perPage: number, status: string = 'all'): Observable<PaginatedInternalAnnouncement> {
+    return this.http.get<PaginatedInternalAnnouncement>(`${this.apiUrl}/management/paginated?page=${page}&perPage=${perPage}&status=${status}`)
+      .pipe(catchError(this.handleError));
+  }
+
   getById(id: number): Observable<InternalAnnouncement> {
     return this.http.get<InternalAnnouncement>(`${this.apiUrl}/${id}`)
+      .pipe(catchError(this.handleError));
+  }
+
+  getManagementById(id: number): Observable<InternalAnnouncement> {
+    return this.http.get<InternalAnnouncement>(`${this.apiUrl}/management/${id}`)
       .pipe(catchError(this.handleError));
   }
 

--- a/portalsantacasa.client/src/app/core/services/news.service.ts
+++ b/portalsantacasa.client/src/app/core/services/news.service.ts
@@ -39,6 +39,24 @@ export class NewsService {
     );
   }
 
+  getManagementNewsPaginated(
+    page: number = 1,
+    perPage: number = 10,
+    isQualityMinute?: boolean,
+    status: string = 'all'
+  ): Observable<{ currentPage: number, perPage: number, pages: number, news: News[] }> {
+    const params: any = { page, perPage, status };
+
+    if (isQualityMinute !== undefined) {
+      params.isQualityMinute = isQualityMinute;
+    }
+
+    return this.http.get<{ currentPage: number, perPage: number, pages: number, news: News[] }>(
+      `${this.apiUrl}/management/paginated`,
+      { params }
+    ).pipe(catchError(this.handleError));
+  }
+
   getNewsTotals(isQualityMinute: boolean): Observable<{ totalNews: number, activeNews: number, inactiveNews: number }> {
     return this.http.get<{ totalNews: number, activeNews: number, inactiveNews: number }>(`${this.apiUrl}/totals?isQualityMinute=${isQualityMinute}`).pipe(
 
@@ -48,6 +66,12 @@ export class NewsService {
 
   getNewsById(id: number): Observable<News> {
     return this.http.get<News>(`${this.apiUrl}/${id}`).pipe(
+      catchError(this.handleError)
+    );
+  }
+
+  getManagementNewsById(id: number): Observable<News> {
+    return this.http.get<News>(`${this.apiUrl}/management/${id}`).pipe(
       catchError(this.handleError)
     );
   }


### PR DESCRIPTION
Refactor controllers to split public and management flows. Public GetAll/GetById endpoints now always return only public/active items and no longer perform content-manager checks. New authorized management endpoints (management/paginated and management/{id}) were added for InternalAnnouncement and News — these use owner scope and accept status filters. Client admin components updated to call the management endpoints and services now include getManagementPaginated/getManagementById methods. Also simplified search/pagination to use active/public defaults.