### PR TITLE
Add image lightbox/zoom to news pages

### DIFF
--- a/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.css
+++ b/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.css
@@ -166,6 +166,7 @@
 }
 
 .article-image {
+  position: relative;
   display: flex;
   height: clamp(330px, 48vw, 620px);
   overflow: hidden;
@@ -175,6 +176,10 @@
   background:
     linear-gradient(145deg, rgba(34, 188, 238, 0.09), rgba(23, 35, 60, 0.04)),
     #f1f5f9;
+  width: 100%;
+  padding: 0;
+  border: 0;
+  cursor: zoom-in;
 }
 
 .article-image img {
@@ -359,9 +364,111 @@
 }
 
 .related-image {
+  position: relative;
   min-height: 150px;
   overflow: hidden;
   background: #eaf2f6;
+}
+
+.related-image[role="button"] {
+  cursor: zoom-in;
+}
+
+.article-image:focus-visible,
+.related-image[role="button"]:focus-visible {
+  outline: 3px solid var(--public-primary);
+  outline-offset: -3px;
+}
+
+.image-zoom-hint {
+  position: absolute;
+  z-index: 1;
+  right: 14px;
+  bottom: 14px;
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: 50%;
+  color: #fff;
+  background: rgba(23, 35, 60, 0.78);
+  box-shadow: 0 8px 20px rgba(23, 35, 60, 0.25);
+  backdrop-filter: blur(8px);
+  pointer-events: none;
+}
+
+.related-image .image-zoom-hint {
+  right: 8px;
+  bottom: 8px;
+  width: 30px;
+  height: 30px;
+  font-size: 11px;
+}
+
+.image-lightbox {
+  position: fixed;
+  z-index: 2000;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(16px, 4vw, 48px);
+  background: rgba(8, 15, 28, 0.9);
+  backdrop-filter: blur(8px);
+  cursor: zoom-out;
+  animation: lightbox-fade-in 180ms ease-out;
+}
+
+.image-lightbox-content {
+  position: relative;
+  display: flex;
+  max-width: min(94vw, 1500px);
+  max-height: 92vh;
+  align-items: center;
+  flex-direction: column;
+  cursor: default;
+}
+
+.image-lightbox-content img {
+  display: block;
+  max-width: 100%;
+  max-height: calc(92vh - 48px);
+  border-radius: 12px;
+  object-fit: contain;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+}
+
+.image-lightbox-content p {
+  max-width: min(88vw, 900px);
+  margin: 12px 0 0;
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 14px;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.image-lightbox-close {
+  position: absolute;
+  z-index: 1;
+  top: -14px;
+  right: -14px;
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  color: #fff;
+  background: rgba(23, 35, 60, 0.92);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+@keyframes lightbox-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
 }
 
 .related-image img {
@@ -650,7 +757,8 @@
   .related-card,
   .share-action,
   .skeleton-line::after,
-  .skeleton-cover::after {
+  .skeleton-cover::after,
+  .image-lightbox {
     animation: none;
     transition: none;
   }

--- a/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.html
+++ b/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.html
@@ -76,11 +76,15 @@
       <div class="article-layout-grid"
            [ngClass]="{'layout-vertical': isVertical, 'layout-horizontal': !isVertical}">
         <figure *ngIf="news.imageUrl" class="article-image-section">
-          <div class="article-image">
+          <button type="button"
+                  class="article-image"
+                  (click)="openImage(news.imageUrl, news.title)"
+                  [attr.aria-label]="'Ampliar imagem de ' + news.title">
             <img [src]="news.imageUrl"
                  [alt]="news.title"
                  (load)="checkOrientation($event)" />
-          </div>
+            <span class="image-zoom-hint" aria-hidden="true"><i class="fas fa-expand"></i></span>
+          </button>
         </figure>
 
         <section class="article-content">
@@ -110,15 +114,25 @@
         <a class="related-card"
            *ngFor="let related of relatedNews; trackBy: trackByNewsId"
            [routerLink]="['/noticia', related.id]">
-          <div class="related-image">
-            <img *ngIf="related.imageUrl"
+          <div class="related-image"
+               *ngIf="related.imageUrl; else relatedImagePlaceholder"
+               role="button"
+               tabindex="0"
+               [attr.aria-label]="'Ampliar imagem de ' + related.title"
+               (click)="openImage(related.imageUrl, related.title, $event)"
+               (keydown.enter)="openImage(related.imageUrl, related.title, $event)"
+               (keydown.space)="openImage(related.imageUrl, related.title, $event)">
+            <img
                  [src]="related.imageUrl"
                  [alt]="related.title"
                  loading="lazy">
-            <div class="related-placeholder" *ngIf="!related.imageUrl">
+            <span class="image-zoom-hint" aria-hidden="true"><i class="fas fa-expand"></i></span>
+          </div>
+          <ng-template #relatedImagePlaceholder>
+            <div class="related-image related-placeholder">
               <i class="far fa-newspaper"></i>
             </div>
-          </div>
+          </ng-template>
           <div class="related-copy">
             <time [attr.datetime]="related.createdAt">{{ related.createdAt | date:'dd MMM yyyy' }}</time>
             <h3>{{ related.title }}</h3>
@@ -127,5 +141,20 @@
         </a>
       </div>
     </section>
+  </div>
+
+  <div *ngIf="selectedImageUrl"
+       class="image-lightbox"
+       role="dialog"
+       aria-modal="true"
+       [attr.aria-label]="selectedImageAlt"
+       (click)="closeImage()">
+    <div class="image-lightbox-content" (click)="$event.stopPropagation()">
+      <button type="button" class="image-lightbox-close" (click)="closeImage()" aria-label="Fechar imagem ampliada">
+        <i class="fas fa-xmark"></i>
+      </button>
+      <img [src]="selectedImageUrl" [alt]="selectedImageAlt">
+      <p>{{ selectedImageAlt }}</p>
+    </div>
   </div>
 </main>

--- a/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.ts
+++ b/portalsantacasa.client/src/app/pages/news-detail/news-detail.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, HostListener, OnInit } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NewsService } from '../../core/services/news.service';
 import { environment } from '../../../environments/environment';
@@ -20,6 +20,8 @@ export class NewsDetailComponent implements OnInit {
   isQualityMinute: boolean = false;
   isVertical: boolean = false; // Variável de controle de layout
   isAccessLogModalOpen = false;
+  selectedImageUrl: string | null = null;
+  selectedImageAlt = '';
   private accessRegisteredForId?: number;
 
   constructor(
@@ -48,6 +50,25 @@ export class NewsDetailComponent implements OnInit {
   checkOrientation(event: Event) {
     const img = event.target as HTMLImageElement;
     this.isVertical = img.naturalHeight > img.naturalWidth;
+  }
+
+  openImage(imageUrl: string, imageAlt: string, event?: Event): void {
+    if (!imageUrl) return;
+
+    event?.preventDefault();
+    event?.stopPropagation();
+    this.selectedImageUrl = imageUrl;
+    this.selectedImageAlt = imageAlt || 'Imagem da publicação';
+  }
+
+  closeImage(): void {
+    this.selectedImageUrl = null;
+    this.selectedImageAlt = '';
+  }
+
+  @HostListener('document:keydown.escape')
+  closeImageOnEscape(): void {
+    if (this.selectedImageUrl) this.closeImage();
   }
 
   fetchNews(id: number) {

--- a/portalsantacasa.client/src/app/pages/news-view/news-view.component.css
+++ b/portalsantacasa.client/src/app/pages/news-view/news-view.component.css
@@ -687,13 +687,106 @@
   }
 }
 
+.is-zoomable {
+  cursor: zoom-in;
+}
+
+.is-zoomable:focus-visible {
+  outline: 3px solid var(--public-primary);
+  outline-offset: -3px;
+}
+
+.image-zoom-hint {
+  position: absolute;
+  z-index: 2;
+  right: 14px;
+  bottom: 14px;
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: 50%;
+  color: #fff;
+  background: rgba(23, 35, 60, 0.78);
+  box-shadow: 0 8px 20px rgba(23, 35, 60, 0.25);
+  backdrop-filter: blur(8px);
+  pointer-events: none;
+}
+
+.image-lightbox {
+  position: fixed;
+  z-index: 2000;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: clamp(16px, 4vw, 48px);
+  background: rgba(8, 15, 28, 0.9);
+  backdrop-filter: blur(8px);
+  cursor: zoom-out;
+  animation: lightbox-fade-in 180ms ease-out;
+}
+
+.image-lightbox-content {
+  position: relative;
+  display: flex;
+  max-width: min(94vw, 1500px);
+  max-height: 92vh;
+  align-items: center;
+  flex-direction: column;
+  cursor: default;
+}
+
+.image-lightbox-content img {
+  display: block;
+  max-width: 100%;
+  max-height: calc(92vh - 48px);
+  border-radius: 12px;
+  object-fit: contain;
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+}
+
+.image-lightbox-content p {
+  max-width: min(88vw, 900px);
+  margin: 12px 0 0;
+  overflow: hidden;
+  color: rgba(255, 255, 255, 0.88);
+  font-size: 14px;
+  text-align: center;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.image-lightbox-close {
+  position: absolute;
+  z-index: 1;
+  top: -14px;
+  right: -14px;
+  display: grid;
+  width: 44px;
+  height: 44px;
+  place-items: center;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  border-radius: 50%;
+  color: #fff;
+  background: rgba(23, 35, 60, 0.92);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  cursor: pointer;
+}
+
+@keyframes lightbox-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .main-news-card,
   .news-card,
   .main-news-image img,
   .news-card-image img,
   .skeleton::after,
-  .card-skeleton::after {
+  .card-skeleton::after,
+  .image-lightbox {
     animation: none;
     transition: none;
   }

--- a/portalsantacasa.client/src/app/pages/news-view/news-view.component.html
+++ b/portalsantacasa.client/src/app/pages/news-view/news-view.component.html
@@ -48,10 +48,20 @@
     <ng-container *ngIf="!isLoading && !hasError">
       <section class="main-news-section" *ngIf="mainNews">
         <a class="main-news-card" [routerLink]="['/noticia', mainNews.id]">
-          <div class="main-news-image">
+          <div class="main-news-image"
+               [class.is-zoomable]="mainNews.imageUrl"
+               [attr.role]="mainNews.imageUrl ? 'button' : null"
+               [attr.tabindex]="mainNews.imageUrl ? 0 : null"
+               [attr.aria-label]="mainNews.imageUrl ? 'Ampliar imagem de ' + mainNews.title : null"
+               (click)="openImage($event, mainNews.imageUrl, mainNews.title)"
+               (keydown.enter)="openImage($event, mainNews.imageUrl, mainNews.title)"
+               (keydown.space)="openImage($event, mainNews.imageUrl, mainNews.title)">
             <img *ngIf="mainNews.imageUrl; else mainNewsPlaceholder"
                  [src]="mainNews.imageUrl"
                  [alt]="mainNews.title || 'Imagem da notícia em destaque'">
+            <span *ngIf="mainNews.imageUrl" class="image-zoom-hint" aria-hidden="true">
+              <i class="fas fa-expand"></i>
+            </span>
             <ng-template #mainNewsPlaceholder>
               <div class="news-image-placeholder"><i class="fas fa-newspaper"></i></div>
             </ng-template>
@@ -97,11 +107,21 @@
           <a class="news-card"
              *ngFor="let news of newsList; trackBy: trackByNewsId"
              [routerLink]="['/noticia', news.id]">
-            <div class="news-card-image">
+            <div class="news-card-image"
+                 [class.is-zoomable]="news.imageUrl"
+                 [attr.role]="news.imageUrl ? 'button' : null"
+                 [attr.tabindex]="news.imageUrl ? 0 : null"
+                 [attr.aria-label]="news.imageUrl ? 'Ampliar imagem de ' + news.title : null"
+                 (click)="openImage($event, news.imageUrl, news.title)"
+                 (keydown.enter)="openImage($event, news.imageUrl, news.title)"
+                 (keydown.space)="openImage($event, news.imageUrl, news.title)">
               <img *ngIf="news.imageUrl; else newsCardPlaceholder"
                    [src]="news.imageUrl"
                    [alt]="news.title || 'Imagem da notícia'"
                    loading="lazy">
+              <span *ngIf="news.imageUrl" class="image-zoom-hint" aria-hidden="true">
+                <i class="fas fa-expand"></i>
+              </span>
               <ng-template #newsCardPlaceholder>
                 <div class="news-image-placeholder"><i class="fas fa-newspaper"></i></div>
               </ng-template>
@@ -170,5 +190,20 @@
         <span class="pagination-status">Página {{ currentPage }} de {{ totalPages }}</span>
       </nav>
     </ng-container>
+  </div>
+
+  <div *ngIf="selectedImageUrl"
+       class="image-lightbox"
+       role="dialog"
+       aria-modal="true"
+       [attr.aria-label]="selectedImageAlt"
+       (click)="closeImage()">
+    <div class="image-lightbox-content" (click)="$event.stopPropagation()">
+      <button type="button" class="image-lightbox-close" (click)="closeImage()" aria-label="Fechar imagem ampliada">
+        <i class="fas fa-xmark"></i>
+      </button>
+      <img [src]="selectedImageUrl" [alt]="selectedImageAlt">
+      <p>{{ selectedImageAlt }}</p>
+    </div>
   </div>
 </main>

--- a/portalsantacasa.client/src/app/pages/news-view/news-view.component.ts
+++ b/portalsantacasa.client/src/app/pages/news-view/news-view.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 import { News } from '../../models/news.model';
 import { NewsService } from '../../core/services/news.service';
 import { environment } from '../../../environments/environment';
@@ -21,6 +21,8 @@ export class NewsViewComponent {
 
   isLoading = true;
   hasError = false;
+  selectedImageUrl: string | null = null;
+  selectedImageAlt = '';
 
   constructor(
     private newsService: NewsService,
@@ -85,6 +87,25 @@ export class NewsViewComponent {
 
   trackByNewsId(index: number, news: News): number | string {
     return news.id ?? `${news.title}-${index}`;
+  }
+
+  openImage(event: Event, imageUrl: string, imageAlt: string): void {
+    if (!imageUrl) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.selectedImageUrl = imageUrl;
+    this.selectedImageAlt = imageAlt || 'Imagem da publicação';
+  }
+
+  closeImage(): void {
+    this.selectedImageUrl = null;
+    this.selectedImageAlt = '';
+  }
+
+  @HostListener('document:keydown.escape')
+  closeImageOnEscape(): void {
+    if (this.selectedImageUrl) this.closeImage();
   }
 
   private formatImageUrl(imagePath: string): string {


### PR DESCRIPTION
Adds an accessible image zoom/lightbox to news-detail and news-view. Wraps images in button/interactive elements with ARIA labels, keyboard handlers (Enter/Space), focus-visible styles and a zoom hint. Implements lightbox markup, CSS (overlay, animations, reduced-motion handling) and caption/close UI. TS changes introduce selectedImageUrl/Alt, openImage/closeImage methods, HostListener to close on Escape, and event propagation control to avoid router navigation. Modified files: news-detail.{ts,html,css} and news-view.{ts,html,css}.