### PR TITLE
Client-side pagination and dashboard accessibility

### DIFF
--- a/portalsantacasa.client/src/app/admin/admin-routing.module.ts
+++ b/portalsantacasa.client/src/app/admin/admin-routing.module.ts
@@ -48,8 +48,8 @@ const routes: Routes = [
   { path: 'point-rules', component: PointRulesComponent, canActivate: [RoleGuard], data: { title: 'Regras de Pontuação', roles: ['admin', 'editor'] } },
   { path: 'profile', component: ProfileComponent, canActivate: [RoleGuard], data: { title: 'Meu Perfil', roles: ['admin', 'editor', 'viewer'] } },
   { path: 'settings', component: SettingsComponent, canActivate: [RoleGuard], data: { title: 'Configurações', roles: ['admin', 'editor', 'viewer'] } },
-  { path: 'ti/relatorios', component: TacticalReportsComponent, canActivate: [RoleGuard], data: { title: 'Central de Gestão de TI', roles: ['admin', 'editor'] } },
-  { path: 'ti/relatorios/:slug', component: TacticalReportsComponent, canActivate: [RoleGuard], data: { title: 'Relatório de TI', roles: ['admin', 'editor'] } },
+  //{ path: 'ti/relatorios', component: TacticalReportsComponent, canActivate: [RoleGuard], data: { title: 'Central de Gestão de TI', roles: ['admin', 'editor'] } },
+  //{ path: 'ti/relatorios/:slug', component: TacticalReportsComponent, canActivate: [RoleGuard], data: { title: 'Relatório de TI', roles: ['admin', 'editor'] } },
   { path: '', redirectTo: 'dashboard', pathMatch: 'full' }
 ];
 

--- a/portalsantacasa.client/src/app/admin/components/admin-sidebar/sidebar-config.ts
+++ b/portalsantacasa.client/src/app/admin/components/admin-sidebar/sidebar-config.ts
@@ -189,14 +189,14 @@ export const SIDEBAR_CONFIG: SidebarSection[] = [
           }
         ]
       },
-      {
+      /*{
         id: 'ti-reports',
         label: 'Gestão de TI',
         icon: 'fas fa-server',
         routerLink: '/admin/ti/relatorios',
         type: 'admin',
         roles: ['admin', 'editor']
-      },
+      },*/
       {
         id: 'analytics',
         label: 'Analytics',

--- a/portalsantacasa.client/src/app/admin/pages/banners/banners.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/banners/banners.component.ts
@@ -259,16 +259,18 @@ export class BannersComponent implements OnInit {
   // 📌 Busca e filtros
   // =====================
   onSearch(): void {
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   setStatusFilter(filter: 'all' | 'active' | 'inactive'): void {
     this.statusFilter = filter;
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   private applyFilters(): void {
-    this.filteredBanners = this.bannersList.filter(banner => {
+    const filtered = this.bannersList.filter(banner => {
       const matchesSearch =
         !this.searchTerm ||
         banner.title.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
@@ -283,7 +285,11 @@ export class BannersComponent implements OnInit {
     });
 
     // Ordenar por ordem
-    this.filteredBanners.sort((a, b) => a.order - b.order);
+    filtered.sort((a, b) => a.order - b.order);
+    this.totalPages = Math.ceil(filtered.length / this.perPage);
+    this.currentPage = Math.min(this.currentPage, Math.max(this.totalPages, 1));
+    const startIndex = (this.currentPage - 1) * this.perPage;
+    this.filteredBanners = filtered.slice(startIndex, startIndex + this.perPage);
   }
 
   // =====================
@@ -292,7 +298,7 @@ export class BannersComponent implements OnInit {
   changePage(page: number): void {
     if (page >= 1 && page <= this.totalPages) {
       this.currentPage = page;
-      this.loadBanners();
+      this.applyFilters();
     }
   }
 

--- a/portalsantacasa.client/src/app/admin/pages/birthdays/birthdays.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/birthdays/birthdays.component.ts
@@ -69,18 +69,16 @@ export class BirthdaysComponent implements OnInit {
   // 📌 CRUD
   // =====================
   loadBirthdays(page: number = 1): void {
-    this.birthdayService.getBirthdaysPaginated(page, this.perPage).subscribe({
-      next: (data) => {
-        this.birthdaysList = data.birthdays.map(b => ({
+    this.birthdayService.getBirthdays().subscribe({
+      next: (birthdays) => {
+        this.birthdaysList = birthdays.map(b => ({
           ...b,
           photoUrl: b.photoUrl ? `${environment.serverUrl}${b.photoUrl}` : ''
         }));
 
         this.updateStatistics();
 
-        this.currentPage = data.currentPage;
-        this.perPage = data.perPage;
-        this.totalPages = data.pages;
+        this.currentPage = page;
 
         this.applyFilters();
       },
@@ -226,16 +224,18 @@ export class BirthdaysComponent implements OnInit {
   // 📌 Busca e filtros
   // =====================
   onSearch(): void {
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   setStatusFilter(filter: 'all' | 'active' | 'inactive'): void {
     this.statusFilter = filter;
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   private applyFilters(): void {
-    this.filteredBirthdays = this.birthdaysList.filter(birthday => {
+    const filtered = this.birthdaysList.filter(birthday => {
       const matchesSearch =
         !this.searchTerm ||
         birthday.name.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
@@ -249,6 +249,11 @@ export class BirthdaysComponent implements OnInit {
 
       return matchesSearch && matchesStatus;
     });
+
+    this.totalPages = Math.ceil(filtered.length / this.perPage);
+    this.currentPage = Math.min(this.currentPage, Math.max(this.totalPages, 1));
+    const startIndex = (this.currentPage - 1) * this.perPage;
+    this.filteredBirthdays = filtered.slice(startIndex, startIndex + this.perPage);
   }
 
   // =====================
@@ -256,7 +261,8 @@ export class BirthdaysComponent implements OnInit {
   // =====================
   changePage(page: number): void {
     if (page >= 1 && page <= this.totalPages) {
-      this.loadBirthdays(page);
+      this.currentPage = page;
+      this.applyFilters();
     }
   }
 

--- a/portalsantacasa.client/src/app/admin/pages/dashboard/dashboard.component.css
+++ b/portalsantacasa.client/src/app/admin/pages/dashboard/dashboard.component.css
@@ -217,12 +217,23 @@
   width: 100%;
   height: 100%;
   opacity: 0;
-  transition: opacity 0.5s ease;
+  visibility: hidden;
+  pointer-events: none;
+  transition: opacity 0.5s ease, visibility 0s linear 0.5s;
   display: flex;
 }
 
   .carousel-slide.active {
     opacity: 1;
+    visibility: visible;
+    pointer-events: auto;
+    transition-delay: 0s;
+    cursor: pointer;
+  }
+
+  .carousel-slide.active:focus-visible {
+    outline: 3px solid #0ea5e9;
+    outline-offset: -3px;
   }
 
 .slide-image {
@@ -245,11 +256,13 @@
 
 .slide-content {
   flex: 1;
-  padding: 32px;
+  min-width: 0;
+  padding: 24px 56px 54px 32px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   background: #f8fafc;
+  overflow: hidden;
 }
 
 .slide-category {
@@ -267,22 +280,34 @@
   font-size: 20px;
   font-weight: 700;
   color: #1f2937;
-  margin: 0 0 12px 0;
+  margin: 0 0 10px 0;
   line-height: 1.3;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .slide-description {
   font-size: 14px;
   color: #6b7280;
-  margin: 0 0 16px 0;
+  margin: 0 0 14px 0;
   line-height: 1.5;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 4;
 }
 
 .slide-meta {
   display: flex;
+  flex-wrap: wrap;
   gap: 16px;
   font-size: 12px;
   color: #9ca3af;
+  min-height: 18px;
 }
 
 /* ===== CAROUSEL CONTROLS ===== */
@@ -295,6 +320,7 @@
   justify-content: space-between;
   padding: 0 16px;
   pointer-events: none;
+  z-index: 3;
 }
 
 .carousel-btn {
@@ -320,24 +346,28 @@
 .carousel-indicators {
   position: absolute;
   bottom: 16px;
-  left: 50%;
+  left: 75%;
   transform: translateX(-50%);
   display: flex;
   gap: 8px;
+  z-index: 3;
 }
 
 .indicator {
-  width: 8px;
-  height: 8px;
+  width: 10px;
+  height: 10px;
+  padding: 0;
   border-radius: 50%;
-  border: none;
-  background: rgba(255, 255, 255, 0.5);
+  border: 1px solid rgba(2, 132, 199, 0.35);
+  background: rgba(14, 165, 233, 0.35);
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
   .indicator.active {
-    background: white;
+    background: #0ea5e9;
+    border-color: #0284c7;
+    box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.9);
     transform: scale(1.2);
   }
 
@@ -818,7 +848,7 @@
   }
 
   .slide-content {
-    padding: 20px;
+    padding: 20px 52px 52px 24px;
   }
 
   .fab {
@@ -839,12 +869,33 @@
 
   .slide-image {
     width: 100%;
-    height: 50%;
+    height: 45%;
   }
 
   .slide-content {
-    height: 50%;
-    padding: 16px;
+    height: 55%;
+    padding: 12px 44px 38px 16px;
+  }
+
+  .slide-category {
+    margin-bottom: 8px;
+  }
+
+  .slide-title {
+    font-size: 17px;
+    margin-bottom: 6px;
+    -webkit-line-clamp: 1;
+  }
+
+  .slide-description {
+    font-size: 13px;
+    margin-bottom: 8px;
+    -webkit-line-clamp: 2;
+  }
+
+  .carousel-indicators {
+    bottom: 12px;
+    left: 50%;
   }
 
   .weather-info {

--- a/portalsantacasa.client/src/app/admin/pages/dashboard/dashboard.component.html
+++ b/portalsantacasa.client/src/app/admin/pages/dashboard/dashboard.component.html
@@ -72,7 +72,13 @@
           <div class="carousel-container" *ngIf="news.length > 0">
             <div class="carousel-slide"
                  *ngFor="let new of news; let i = index"
-                 [class.active]="i === currentSlide">
+                 [class.active]="i === currentSlide"
+                 role="link"
+                 [attr.tabindex]="i === currentSlide ? 0 : -1"
+                 [attr.aria-label]="'Ler notícia: ' + new.title"
+                 (click)="openPublicNews(new.newsId)"
+                 (keydown.enter)="openPublicNews(new.newsId)"
+                 (keydown.space)="$event.preventDefault(); openPublicNews(new.newsId)">
 
               <div class="slide-image">
                 <img [src]="new.imageUrl" [alt]="new.title" />
@@ -81,8 +87,8 @@
 
               <div class="slide-content">
                 <span class="slide-category">{{ new.category || 'Notícias' }}</span>
-                <h3 class="slide-title">{{ new.title }}</h3>
-                <p class="slide-description">{{ new.description }}</p>
+                <h3 class="slide-title" [title]="new.title">{{ new.title }}</h3>
+                <p class="slide-description" [title]="new.description">{{ new.description }}</p>
                 <div class="slide-meta">
                   <span class="slide-date">{{ new.date | date:'dd/MM/yyyy' }}</span>
                   <span class="slide-author">{{ new.author }}</span>
@@ -105,6 +111,8 @@
               <button *ngFor="let new of news; let i = index"
                       class="indicator"
                       [class.active]="i === currentSlide"
+                      [attr.aria-label]="'Ir para a notícia ' + (i + 1)"
+                      [attr.aria-current]="i === currentSlide ? 'true' : null"
                       (click)="goToSlide(i)">
               </button>
             </div>

--- a/portalsantacasa.client/src/app/admin/pages/dashboard/dashboard.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/dashboard/dashboard.component.ts
@@ -334,12 +334,14 @@ export class DashboardComponent implements OnInit, OnDestroy {
   private processNewsData(news: News[]): void {
     this.news = news
       .filter(news => news.isActive)
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 5)
       .map(news => ({
         title: news.title,
         description: news.summary,
         imageUrl: `${environment.serverUrl}${news.imageUrl}`,
         category: 'Notícias',
-        date: new Date(),
+        date: new Date(news.createdAt),
         author: 'Sistema',
         newsId: news.id
       }));
@@ -414,6 +416,12 @@ export class DashboardComponent implements OnInit, OnDestroy {
     this.router.navigate(['/admin/news'], {
       queryParams: { quality: false }
     });
+  }
+
+  openPublicNews(newsId?: number): void {
+    if (newsId) {
+      this.router.navigate(['/noticia', newsId]);
+    }
   }
 
   navigateToEvents(): void {

--- a/portalsantacasa.client/src/app/admin/pages/documents/documents.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/documents/documents.component.ts
@@ -79,9 +79,9 @@ export class DocumentsComponent implements OnInit {
           allowedRoles: d.allowedRoles || []
         }));
 
+        this.currentPage = page;
         this.updateStatistics();
         this.applyFilters();
-        this.updatePagination();
       },
       error: (err) => this.handleError('Erro ao carregar documentos', err)
     });
@@ -249,11 +249,13 @@ export class DocumentsComponent implements OnInit {
   // 📌 Busca e filtros
   // =====================
   onSearch(): void {
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   setStatusFilter(filter: 'all' | 'active' | 'inactive'): void {
     this.statusFilter = filter;
+    this.currentPage = 1;
     this.applyFilters();
   }
 
@@ -275,8 +277,11 @@ export class DocumentsComponent implements OnInit {
     this.filteredDocuments = tempFiltered;
 
     // Rebuild tree structure for filtered results
-    this.groupedDocuments = this.buildDocumentTree(tempFiltered);
-    this.updatePagination();
+    const groupedDocuments = this.buildDocumentTree(tempFiltered);
+    this.totalPages = Math.ceil(groupedDocuments.length / this.perPage);
+    this.currentPage = Math.min(this.currentPage, Math.max(this.totalPages, 1));
+    const startIndex = (this.currentPage - 1) * this.perPage;
+    this.groupedDocuments = groupedDocuments.slice(startIndex, startIndex + this.perPage);
   }
 
   private autoExpandFilteredParents(filteredDocs: Document[]): void {
@@ -358,19 +363,6 @@ export class DocumentsComponent implements OnInit {
   // =====================
   // 📌 Paginação
   // =====================
-  private updatePagination(): void {
-    // For tree-like structures, pagination is usually applied to the top-level items
-    // or a flat list. For simplicity, let's paginate the top-level groupedDocuments.
-    const startIndex = (this.currentPage - 1) * this.perPage;
-    const endIndex = startIndex + this.perPage;
-    // This pagination logic needs to be carefully considered for tree structures.
-    // For now, it will paginate the top-level items after filtering.
-    // If sub-items also need pagination, a more complex logic is required.
-    this.totalPages = Math.ceil(this.groupedDocuments.length / this.perPage);
-    // If you want to paginate the flat filtered list, use this:
-    // this.totalPages = Math.ceil(this.filteredDocuments.length / this.perPage);
-  }
-
   changePage(page: number): void {
     if (page >= 1 && page <= this.totalPages) {
       this.currentPage = page;

--- a/portalsantacasa.client/src/app/admin/pages/events/events.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/events/events.component.ts
@@ -76,13 +76,11 @@ export class EventsComponent implements OnInit {
   // =====================
   loadEvents(page: number = 1): void {
     this.isLoading = true;
-    this.eventService.getEventPaginated(page, this.perPage).subscribe({
-      next: (data) => {
-        this.events = data.events;
+    this.eventService.getEvent().subscribe({
+      next: (events) => {
+        this.events = events;
         this.filteredEvents = [...this.events];
-        this.currentPage = data.currentPage;
-        this.perPage = data.perPage;
-        this.totalPages = data.pages;
+        this.currentPage = page;
 
         this.applyFilters();
         this.updateStats();
@@ -228,13 +226,12 @@ export class EventsComponent implements OnInit {
   onSearch(): void {
     this.currentPage = 1;
     this.applyFilters();
-    this.calculatePagination();
   }
 
   changePage(page: number): void {
     if (page >= 1 && page <= this.totalPages) {
       this.currentPage = page;
-      this.loadEvents(page);
+      this.applyFilters();
     }
   }
 
@@ -242,7 +239,6 @@ export class EventsComponent implements OnInit {
     this.statusFilter = filter;
     this.currentPage = 1;
     this.applyFilters();
-    this.calculatePagination();
   }
 
   updateStats(): void {

--- a/portalsantacasa.client/src/app/admin/pages/feedbacks/feedbacks.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/feedbacks/feedbacks.component.ts
@@ -54,13 +54,11 @@ export class FeedbacksComponent implements OnInit {
   // 📌 CRUD e Carregamento
   // =====================
   loadFeedbacks(page: number = 1): void {
-    this.feedbackService.getFeedbackPaginated(page, this.perPage).subscribe({
-      next: (data) => {
-        this.feedbacksList = data.feedbacks.filter(f => f.targetDepartment == this.department);
+    this.feedbackService.getFeedback().subscribe({
+      next: (feedbacks) => {
+        this.feedbacksList = feedbacks.filter(f => f.targetDepartment == this.department);
 
-        this.currentPage = data.currentPage;
-        this.perPage = data.perPage;
-        this.totalPages = data.pages;
+        this.currentPage = page;
 
         this.updateStatistics();
         this.extractUniqueCategories();
@@ -160,21 +158,24 @@ export class FeedbacksComponent implements OnInit {
   // 📌 Busca e filtros
   // =====================
   onSearch(): void {
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   setStatusFilter(status: boolean | null): void {
     this.statusFilter = status;
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   setCategoryFilter(category: string | null): void {
     this.categoryFilter = category;
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   private applyFilters(): void {
-    this.filteredFeedbacks = this.feedbacksList.filter(feedback => {
+    const filtered = this.feedbacksList.filter(feedback => {
       const matchesSearch =
         !this.searchTerm ||
         feedback.subject.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
@@ -193,6 +194,11 @@ export class FeedbacksComponent implements OnInit {
 
       return matchesSearch && matchesStatus && matchesCategory;
     });
+
+    this.totalPages = Math.ceil(filtered.length / this.perPage);
+    this.currentPage = Math.min(this.currentPage, Math.max(this.totalPages, 1));
+    const startIndex = (this.currentPage - 1) * this.perPage;
+    this.filteredFeedbacks = filtered.slice(startIndex, startIndex + this.perPage);
   }
 
   // =====================
@@ -200,7 +206,8 @@ export class FeedbacksComponent implements OnInit {
   // =====================
   changePage(page: number): void {
     if (page >= 1 && page <= this.totalPages) {
-      this.loadFeedbacks(page);
+      this.currentPage = page;
+      this.applyFilters();
     }
   }
 }

--- a/portalsantacasa.client/src/app/admin/pages/internal-announcement/internal-announcement.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/internal-announcement/internal-announcement.component.ts
@@ -97,17 +97,12 @@ export class InternalAnnouncementComponent implements OnInit {
   // 📌 Carregar comunicados
   // =====================
   loadInternals(page: number = 1): void {
-    this.internalService.getManagementPaginated(page, this.perPage).subscribe({
-      next: (res) => {
-        this.internals = res.items;
+    this.internalService.getManagementAll().subscribe({
+      next: (items) => {
+        this.internals = items;
         this.filteredInternals = [...this.internals];
 
-        this.currentPage = res.currentPage;
-        this.totalPages = res.totalPages;
-
-        this.totalInternals = res.totalCount;
-        this.activeInternals = res.items.filter(n => n.isActive).length;
-        this.inactiveInternals = res.items.filter(n => !n.isActive).length;
+        this.currentPage = page;
 
         this.applyFilters();
       },
@@ -121,29 +116,22 @@ export class InternalAnnouncementComponent implements OnInit {
   // =====================
   changePage(page: number): void {
     if (page < 1 || page > this.totalPages) return;
-    this.loadInternals(page);
+    this.currentPage = page;
+    this.applyFilters();
   }
 
   // =====================
   // 📌 Busca e Filtros
   // =====================
   onSearch(): void {
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   setStatusFilter(filter: 'all' | 'active' | 'inactive') {
     this.statusFilter = filter;
-
-    this.internalService.getManagementPaginated(1, this.perPage, filter).subscribe({
-      next: (res) => {
-        this.internals = res.items;
-
-        this.filteredInternals = [...this.internals];
-        this.currentPage = 1;
-        this.totalPages = res.totalPages
-      },
-      error: () => this.toastr.error('Erro ao carregar comunicados internos')
-    });
+    this.currentPage = 1;
+    this.applyFilters();
   }
 
   applyFilters(): void {
@@ -163,7 +151,10 @@ export class InternalAnnouncementComponent implements OnInit {
       list = list.filter(n => !n.isActive);
     }
 
-    this.filteredInternals = list;
+    this.totalPages = Math.ceil(list.length / this.perPage);
+    this.currentPage = Math.min(this.currentPage, Math.max(this.totalPages, 1));
+    const startIndex = (this.currentPage - 1) * this.perPage;
+    this.filteredInternals = list.slice(startIndex, startIndex + this.perPage);
   }
 
   // =====================

--- a/portalsantacasa.client/src/app/admin/pages/news/news.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/news/news.component.ts
@@ -119,18 +119,16 @@ export class NewsComponent implements OnInit {
   // 📌 CRUD
   // =====================
   loadNews(page: number = this.currentPage): void {
-    this.newsService.getManagementNewsPaginated(page, this.perPage, this.isQualityMinute).subscribe({
-      next: (data) => {
-        this.newsList = data.news
-          .filter(n => n.department == this.department)
+    this.newsService.getNews().subscribe({
+      next: (news) => {
+        this.newsList = news
+          .filter(n => n.isQualityMinute === this.isQualityMinute && n.department == this.department)
           .map(n => ({
             ...n,
             imageUrl: n.imageUrl ? `${environment.serverUrl}${n.imageUrl}` : ''
           }));
 
-        this.currentPage = data.currentPage;
-        this.perPage = data.perPage;
-        this.totalPages = data.pages;
+        this.currentPage = page;
 
         this.applyFilters();
       },
@@ -302,28 +300,18 @@ export class NewsComponent implements OnInit {
   // 📌 Busca e filtros
   // =====================
   onSearch(): void {
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   setStatusFilter(filter: 'all' | 'active' | 'inactive') {
     this.statusFilter = filter;
-
-    this.newsService.getManagementNewsPaginated(1, this.perPage, this.isQualityMinute, filter).subscribe({
-      next: data => {
-        this.newsList = data.news.filter(n => n.department == this.department).map(n => ({
-          ...n,
-          imageUrl: n.imageUrl ? `${environment.serverUrl}${n.imageUrl}` : ''
-        }));
-
-        this.filteredNews = this.newsList;
-        this.currentPage = 1;
-        this.totalPages = data.pages;
-      }
-    });
+    this.currentPage = 1;
+    this.applyFilters();
   }
 
   private applyFilters(): void {
-    this.filteredNews = this.newsList.filter(news => {
+    const filtered = this.newsList.filter(news => {
       const matchesSearch =
         !this.searchTerm ||
         news.title.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
@@ -336,6 +324,11 @@ export class NewsComponent implements OnInit {
 
       return matchesSearch && matchesStatus;
     });
+
+    this.totalPages = Math.ceil(filtered.length / this.perPage);
+    this.currentPage = Math.min(this.currentPage, Math.max(this.totalPages, 1));
+    const startIndex = (this.currentPage - 1) * this.perPage;
+    this.filteredNews = filtered.slice(startIndex, startIndex + this.perPage);
   }
 
   // =====================
@@ -343,7 +336,8 @@ export class NewsComponent implements OnInit {
   // =====================
   changePage(page: number): void {
     if (page >= 1 && page <= this.totalPages) {
-      this.loadNews(page);
+      this.currentPage = page;
+      this.applyFilters();
     }
   }
 

--- a/portalsantacasa.client/src/app/admin/pages/users/users.component.ts
+++ b/portalsantacasa.client/src/app/admin/pages/users/users.component.ts
@@ -58,7 +58,7 @@ export class UsersComponent implements OnInit, OnDestroy {
     this.routeSubscription = this.route.queryParamMap.subscribe(params => {
       const search = params.get('search')?.trim() || '';
       this.searchTerm = search;
-      search ? this.loadSearchResults(search) : this.loadUsers();
+      this.loadUsers();
     });
   }
 
@@ -102,16 +102,14 @@ export class UsersComponent implements OnInit, OnDestroy {
   // 📌 CRUD e Carregamento
   // =====================
   loadUsers(page: number = 1): void {
-    this.userService.getUsersPaginated(page, this.perPage).subscribe({
-      next: (data) => {
-        this.usersList = data.users.map(user => ({
+    this.userService.getUser().subscribe({
+      next: (users) => {
+        this.usersList = users.map(user => ({
           ...user,
           photoUrl: user.photoUrl ? `${environment.serverUrl}${user.photoUrl}` : ''
         }));
 
-        this.currentPage = data.currentPage;
-        this.perPage = data.perPage;
-        this.totalPages = data.pages;
+        this.currentPage = page;
 
         this.updateStatistics();
         this.applyFilters();
@@ -278,16 +276,18 @@ export class UsersComponent implements OnInit, OnDestroy {
   // 📌 Busca e filtros
   // =====================
   onSearch(): void {
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   setStatusFilter(status: boolean | null): void {
     this.statusFilter = status;
+    this.currentPage = 1;
     this.applyFilters();
   }
 
   private applyFilters(): void {
-    this.filteredUsers = this.usersList.filter(user => {
+    const filtered = this.usersList.filter(user => {
       const matchesSearch =
         !this.searchTerm ||
         user.username.toLowerCase().includes(this.searchTerm.toLowerCase()) ||
@@ -301,6 +301,11 @@ export class UsersComponent implements OnInit, OnDestroy {
 
       return matchesSearch && matchesStatus;
     });
+
+    this.totalPages = Math.ceil(filtered.length / this.perPage);
+    this.currentPage = Math.min(this.currentPage, Math.max(this.totalPages, 1));
+    const startIndex = (this.currentPage - 1) * this.perPage;
+    this.filteredUsers = filtered.slice(startIndex, startIndex + this.perPage);
   }
 
   // =====================
@@ -308,7 +313,8 @@ export class UsersComponent implements OnInit, OnDestroy {
   // =====================
   changePage(page: number): void {
     if (page >= 1 && page <= this.totalPages) {
-      this.loadUsers(page);
+      this.currentPage = page;
+      this.applyFilters();
     }
   }
 

--- a/portalsantacasa.client/src/app/core/services/internal-announcement.service.ts
+++ b/portalsantacasa.client/src/app/core/services/internal-announcement.service.ts
@@ -23,6 +23,11 @@ export class InternalAnnouncementService {
       .pipe(catchError(this.handleError));
   }
 
+  getManagementAll(): Observable<InternalAnnouncement[]> {
+    return this.http.get<InternalAnnouncement[]>(`${this.apiUrl}/all`)
+      .pipe(catchError(this.handleError));
+  }
+
   getById(id: number): Observable<InternalAnnouncement> {
     return this.http.get<InternalAnnouncement>(`${this.apiUrl}/${id}`)
       .pipe(catchError(this.handleError));


### PR DESCRIPTION
Migrate multiple admin lists from server-side paginated endpoints to client-side pagination/filtering (banners, birthdays, documents, events, feedbacks, internals, news, users). Reset currentPage on search/filters, apply slicing in applyFilters(), and unify changePage behavior. Improve dashboard carousel accessibility, add sorting/date fixes and openPublicNews navigation. Comment out TI routes/sidebar entry. Add InternalAnnouncementService.getManagementAll() to support full-list loading. Minor CSS and layout adjustments for responsive/accessible carousel.