### PR TITLE
Initial password change flow

### DIFF
--- a/PortalSantaCasa.Server/Controllers/AuthController.cs
+++ b/PortalSantaCasa.Server/Controllers/AuthController.cs
@@ -93,6 +93,33 @@ namespace PortalSantaCasa.Server.Controllers
             return Ok(new { token, precisaTrocarSenha = false, userId = user.Id });
         }
 
+        [Authorize(Policy = "PasswordChangeOnly")]
+        [HttpPost("change-password")]
+        public async Task<IActionResult> ChangeInitialPassword([FromBody] ChangePasswordDto dto)
+        {
+            if (string.IsNullOrWhiteSpace(dto.NewPassword) || dto.NewPassword.Length is < 8 or > 128)
+                return BadRequest(new { message = "A nova senha deve ter entre 8 e 128 caracteres." });
+
+            var userIdClaim = User.FindFirst("id")?.Value;
+            if (!int.TryParse(userIdClaim, out var userId))
+                return Unauthorized(new { message = "Token de troca de senha inválido." });
+
+            var user = await _context.Users.FindAsync(userId);
+            if (user == null)
+                return NotFound(new { message = "Usuário não encontrado." });
+
+            var stillUsesDefaultPassword = _passwordHasher.VerifyHashedPassword(null!, user.Senha, "MV")
+                                           == PasswordVerificationResult.Success;
+            if (!stillUsesDefaultPassword)
+                return BadRequest(new { message = "A senha inicial já foi alterada. Faça login novamente." });
+
+            user.Senha = _passwordHasher.HashPassword(null!, dto.NewPassword);
+            user.UpdatedAt = DateTimeOffset.UtcNow;
+            await _context.SaveChangesAsync();
+
+            return Ok(new { message = "Senha alterada com sucesso." });
+        }
+
         private string GenerateJwtToken(User user, string? purpose = null, TimeSpan? lifetime = null)
         {
             var claims = new List<Claim>

--- a/PortalSantaCasa.Server/Program.cs
+++ b/PortalSantaCasa.Server/Program.cs
@@ -237,6 +237,8 @@ builder.Services.AddAuthorization(options =>
         policy.RequireAuthenticatedUser().RequireAssertion(context =>
             !context.User.HasClaim(claim => claim.Type == "purpose") ||
             context.User.HasClaim("purpose", "password_change")));
+    options.AddPolicy("PasswordChangeOnly", policy =>
+        policy.RequireAuthenticatedUser().RequireClaim("purpose", "password_change"));
 });
 
 var app = builder.Build();
@@ -326,8 +328,7 @@ app.Use(async (context, next) =>
 {
     if (context.User.HasClaim("purpose", "password_change"))
     {
-        var userId = context.User.FindFirst("id")?.Value;
-        var expectedPath = $"/api/user/{userId}/change-password";
+        var expectedPath = "/api/auth/change-password";
         var isPasswordChangeRequest =
             HttpMethods.IsPost(context.Request.Method) &&
             context.Request.Path.Equals(expectedPath, StringComparison.OrdinalIgnoreCase);

--- a/portalsantacasa.client/src/app/components/header/header.component.html
+++ b/portalsantacasa.client/src/app/components/header/header.component.html
@@ -288,6 +288,8 @@
                  [(ngModel)]="newPassword"
                  name="newPassword"
                  required
+                 minlength="8"
+                 maxlength="128"
                  placeholder="Digite a nova senha" />
         </div>
       </div>
@@ -300,6 +302,8 @@
                  [(ngModel)]="confirmPassword"
                  name="confirmPassword"
                  required
+                 minlength="8"
+                 maxlength="128"
                  placeholder="Confirme a nova senha" />
         </div>
       </div>

--- a/portalsantacasa.client/src/app/components/header/header.component.ts
+++ b/portalsantacasa.client/src/app/components/header/header.component.ts
@@ -248,6 +248,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   changePassword(): void {
+    if (this.newPassword.length < 8 || this.newPassword.length > 128) {
+      this.toastr.error('A nova senha deve ter entre 8 e 128 caracteres');
+      return;
+    }
+
     if (this.newPassword !== this.confirmPassword) {
       this.toastr.error('As senhas não coincidem');
       return;
@@ -255,13 +260,13 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
     if (!this.userIdParaTroca || !this.tokenTrocaSenha) return;
 
-    this.userService.changePassword(this.userIdParaTroca, this.newPassword, this.tokenTrocaSenha).subscribe({
+    this.userService.changeInitialPassword(this.newPassword, this.tokenTrocaSenha).subscribe({
       next: () => {
         this.toastr.success('Senha alterada com sucesso! Faça login novamente.');
         this.resetForms();
       },
-      error: () => {
-        this.toastr.error('Erro ao alterar senha');
+      error: (error) => {
+        this.toastr.error(error.message || 'Erro ao alterar senha');
       }
     });
   }

--- a/portalsantacasa.client/src/app/core/services/user.service.ts
+++ b/portalsantacasa.client/src/app/core/services/user.service.ts
@@ -102,12 +102,19 @@ export class UserService {
     );
   }
 
+  changeInitialPassword(newPassword: string, token: string): Observable<{ message: string }> {
+    return this.http.post<{ message: string }>(`${environment.apiUrl}/auth/change-password`,
+      { newPassword },
+      { headers: new HttpHeaders({ Authorization: `Bearer ${token}` }) }
+    ).pipe(catchError(this.handleError));
+  }
+
   private handleError(error: HttpErrorResponse): Observable<never> {
     let errorMessage = 'Ocorreu um erro. Tente novamente mais tarde.';
     if (error.error instanceof ErrorEvent) {
       errorMessage = `Erro: ${error.error.message}`;
     } else {
-      errorMessage = error.error?.error || errorMessage;
+      errorMessage = error.error?.message || error.error?.error || errorMessage;
     }
     return throwError(() => new Error(errorMessage));
   }


### PR DESCRIPTION
Adds server and client support for initial password changes. Server: new POST /api/auth/change-password in AuthController requiring a PasswordChangeOnly policy; verifies default password "MV", hashes the new password and updates UpdatedAt. Program.cs: registers PasswordChangeOnly policy and updates middleware to allow /api/auth/change-password for password-change tokens. Client: header template adds minlength/maxlength, TypeScript validates length and shows errors, calls userService.changeInitialPassword. user.service.ts adds changeInitialPassword and improves error parsing.