### PR TITLE
Add excluded paths to tsconfig.json

### DIFF
--- a/portalsantacasa.client/tsconfig.json
+++ b/portalsantacasa.client/tsconfig.json
@@ -1,5 +1,3 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
-/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "compileOnSave": false,
   "compilerOptions": {
@@ -18,6 +16,15 @@
     "target": "ES2022",
     "module": "ES2022"
   },
+  "exclude": [
+    "node_modules",
+    "dist",
+    "out-tsc",
+    "obj",
+    "obj/**",
+    ".angular",
+    ".angular/**"
+  ],
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
     "strictInjectionParameters": true,


### PR DESCRIPTION
Add an "exclude" array to portalsantacasa.client/tsconfig.json to ignore node_modules, dist, out-tsc, obj and Angular build/metadata folders (including glob patterns). This narrows TypeScript/Angular compilation scope and avoids processing build artifacts and IDE folders. Also removed two top-of-file comment lines to clean up the file header.