### PR TITLE
Add exclude patterns to tsconfig.app.json

### DIFF
--- a/portalsantacasa.client/tsconfig.app.json
+++ b/portalsantacasa.client/tsconfig.app.json
@@ -1,5 +1,3 @@
-/* To learn more about Typescript configuration file: https://www.typescriptlang.org/docs/handbook/tsconfig-json.html. */
-/* To learn more about Angular compiler options: https://angular.dev/reference/configs/angular-compiler-options. */
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
@@ -11,5 +9,14 @@
   ],
   "include": [
     "src/**/*.d.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "out-tsc",
+    "obj",
+    "obj/**",
+    ".angular",
+    ".angular/**"
   ]
 }


### PR DESCRIPTION
Remove documentation comments and add exclude patterns to prevent TypeScript compilation of build artifacts (dist, out-tsc, obj), dependencies (node_modules), and Angular cache (.angular). This improves build performance and prevents unnecessary type checking of generated and dependency files.