### PR TITLE
Add Angular directory preparation step to production workflow

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -78,6 +78,11 @@ jobs:
         working-directory: ${{ env.FRONTEND_DIR }}
         run: npm ci
 
+      - name: Preparar diretórios Angular
+        run: |
+          mkdir -p ${{ env.FRONTEND_DIR }}/obj/Debug
+          mkdir -p ${{ env.FRONTEND_DIR }}/obj/Release
+
       - name: Build Angular
         working-directory: ${{ env.FRONTEND_DIR }}
         run: npm run build -- --configuration production


### PR DESCRIPTION
Create obj/Debug and obj/Release directories before building Angular. This ensures the required directory structure exists for the build process to succeed.