### PR TITLE
Add parent breadcrumb support to admin layout

### DIFF
--- a/portalsantacasa.client/src/app/admin/layout/admin-layout/admin-layout.component.html
+++ b/portalsantacasa.client/src/app/admin/layout/admin-layout/admin-layout.component.html
@@ -19,7 +19,15 @@
                 <i class="fas fa-home"></i>
               </a>
             </li>
-            <li class="breadcrumb-item" *ngIf="currentPageTitle">
+            <li class="breadcrumb-item" *ngFor="let parent of breadcrumbParents">
+              <a *ngIf="parent.routerLink; else parentLabel"
+                 [routerLink]="parent.routerLink"
+                 [queryParams]="parent.queryParams">
+                {{ parent.label }}
+              </a>
+              <ng-template #parentLabel>{{ parent.label }}</ng-template>
+            </li>
+            <li class="breadcrumb-item" *ngIf="currentPageTitle" aria-current="page">
               {{ currentPageTitle }}
             </li>
           </ol>

--- a/portalsantacasa.client/src/app/admin/layout/admin-layout/admin-layout.component.ts
+++ b/portalsantacasa.client/src/app/admin/layout/admin-layout/admin-layout.component.ts
@@ -7,12 +7,19 @@ import { AuthService } from '../../../core/services/auth.service';
 import { SidebarConfigService, SidebarPermissions } from '../../components/admin-sidebar/sidebar-config.service';
 import { AdminSidebarComponent } from '../../components/admin-sidebar/admin-sidebar.component';
 import { UserPreferencesService } from '../../../core/services/user-preferences.service';
+import { SIDEBAR_CONFIG, SidebarItem } from '../../components/admin-sidebar/sidebar-config';
 
 interface Notification {
   id: string;
   type: 'success' | 'error' | 'warning' | 'info';
   message: string;
   timestamp: Date;
+}
+
+interface BreadcrumbItem {
+  label: string;
+  routerLink?: string;
+  queryParams?: { [key: string]: any };
 }
 
 @Component({
@@ -31,6 +38,7 @@ export class AdminLayoutComponent implements OnInit, OnDestroy {
   canConfigureSidebar = false;
   showBreadcrumb = true;
   currentPageTitle = '';
+  breadcrumbParents: BreadcrumbItem[] = [];
   notifications: Notification[] = [];
 
   constructor(
@@ -46,6 +54,7 @@ export class AdminLayoutComponent implements OnInit, OnDestroy {
     this.initializeSidebar();
     this.checkUserPermissions();
     this.subscribeToRouterEvents();
+    this.updatePageTitleFromRoute();
     this.loadSavedPreferences();
     this.preferences.preferences$.pipe(takeUntil(this.destroy$)).subscribe(preferences => {
       this.sidebarCollapsed = preferences.sidebarCollapsed;
@@ -96,6 +105,58 @@ export class AdminLayoutComponent implements OnInit, OnDestroy {
     }
 
     this.currentPageTitle = route.snapshot.data['title'] || '';
+    this.updateBreadcrumbParents();
+  }
+
+  private updateBreadcrumbParents(): void {
+    const urlTree = this.router.parseUrl(this.router.url);
+    const segments = urlTree.root.children['primary']?.segments ?? [];
+    const currentPath = `/${segments.map(segment => segment.path).join('/')}`;
+
+    for (const section of SIDEBAR_CONFIG) {
+      const itemPath = this.findSidebarPath(section.items, currentPath, urlTree.queryParams);
+      if (!itemPath) continue;
+
+      this.breadcrumbParents = itemPath.slice(0, -1).map(item => ({
+        label: item.label,
+        routerLink: item.routerLink,
+        queryParams: item.queryParams
+      }));
+      return;
+    }
+
+    this.breadcrumbParents = [];
+  }
+
+  private findSidebarPath(
+    items: SidebarItem[],
+    currentPath: string,
+    queryParams: { [key: string]: any },
+    ancestors: SidebarItem[] = []
+  ): SidebarItem[] | null {
+    for (const item of items) {
+      const path = [...ancestors, item];
+      if (item.routerLink === currentPath && this.matchesQueryParams(item, queryParams)) {
+        return path;
+      }
+
+      if (item.children?.length) {
+        const childPath = this.findSidebarPath(item.children, currentPath, queryParams, path);
+        if (childPath) return childPath;
+      }
+    }
+
+    return null;
+  }
+
+  private matchesQueryParams(item: SidebarItem, actual: { [key: string]: any }): boolean {
+    const expected = item.queryParams;
+    if (!expected) return true;
+
+    return Object.entries(expected).every(([key, value]) => {
+      const actualValue = actual[key] ?? (value === false ? false : undefined);
+      return String(actualValue) === String(value);
+    });
   }
 
   /**


### PR DESCRIPTION
Show parent breadcrumb items in the admin layout. Adds BreadcrumbItem type, breadcrumbParents state and imports SIDEBAR_CONFIG/SidebarItem. New logic (updateBreadcrumbParents, findSidebarPath, matchesQueryParams) derives parent trail from the sidebar config using current URL and query params. Template updated to render parent links (with queryParams) or plain labels and set aria-current on the current page. Also ensures page title is updated on init.